### PR TITLE
Use pypandoc to convert markdown to pypi friendly format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,11 @@ from setuptools import setup, find_packages
 
 PROJECT_DIR = path.abspath(path.dirname(__file__))
 
-with open(path.join(PROJECT_DIR, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
+try:
+    import pypandoc
+    long_description = pypandoc.convert('README.md', 'rst')
+except(IOError, ImportError):
+    long_description = open('README.md').read()
 
 install_requirements = [
 ]


### PR DESCRIPTION
See https://pypi.python.org/pypi/django-migration-linter
And then see https://stackoverflow.com/questions/26737222/pypi-description-markdown-doesnt-work