### PR TITLE
don't assume git root is django_path

### DIFF
--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -195,8 +195,28 @@ class MigrationLinter(object):
         logger.info("Found {0} sql migration lines".format(len(sql_statements)))
         return sql_statements
 
+    def _get_git_root(self):
+        git_root = self.django_path
+        command = "cd {0} && git rev-parse --show-toplevel".format(self.django_path)
+        logger.info("Executing {0}".format(command))
+        diff_process = Popen(command, shell=True, stdout=PIPE, stderr=PIPE)
+        for line in map(clean_bytes_to_str, diff_process.stdout.readlines()):
+            git_root = line
+        diff_process.wait()
+
+        if diff_process.returncode != 0:
+            output = []
+            for line in map(clean_bytes_to_str, diff_process.stderr.readlines()):
+                output.append(line)
+            logger.error(
+                "Error while git rev-parse command:\n{}".format("".join(output))
+            )
+            raise Exception("Error while executing git rev-parse command")
+        return git_root
+
     def _gather_migrations_git(self, git_commit_id):
         migrations = []
+        git_root = self._get_git_root()
         # Get changes since specified commit
         git_diff_command = (
             "cd {0} && git diff --name-only --diff-filter=A {1}"
@@ -209,7 +229,7 @@ class MigrationLinter(object):
                 re.search(r"\/{0}\/.*\.py".format(MIGRATION_FOLDER_NAME), line)
                 and "__init__" not in line
             ):
-                migrations.append(Migration(os.path.join(self.django_path, line)))
+                migrations.append(Migration(os.path.join(git_root, line)))
         diff_process.wait()
 
         if diff_process.returncode != 0:


### PR DESCRIPTION
> DJANGO_SETTINGS_MODULE=xpbx.test django-migration-linter --no-cache $(pwd)/xpbx origin/2.4.1
> (customers, 0010_auto_20181026_1330)... Traceback (most recent call last):
>  File "/home/vseva/Env/xpbx/bin/django-migration-linter", line 11, in <module>
>    sys.exit(_main())
>  File "/home/vseva/Env/xpbx/lib/python3.6/site-packages/django_migration_linter/migration_linter.py", line 341, in _main
>    linter.lint_all_migrations(git_commit_id=args.commit_id)
>  File "/home/vseva/Env/xpbx/lib/python3.6/site-packages/django_migration_linter/migration_linter.py", line 145, in lint_all_migrations
>    self.lint_migration(m)
>  File "/home/vseva/Env/xpbx/lib/python3.6/site-packages/django_migration_linter/migration_linter.py", line 81, in lint_migration
>    md5hash = self.old_cache.md5(migration.abs_path)
>  File "/home/vseva/Env/xpbx/lib/python3.6/site-packages/django_migration_linter/cache.py", line 47, in md5
>    with open(path, "rb") as f:
> FileNotFoundError: [Errno 2] No such file or directory: '/home/vseva/Foehn/xpbx/xpbx/xpbx/customers/migrations/0010_auto_20181026_1330.py'

Fix: #37