### PR TITLE
Make sure file paths from git diff are relative to django_path

### DIFF
--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -199,7 +199,7 @@ class MigrationLinter(object):
         migrations = []
         # Get changes since specified commit
         git_diff_command = (
-            "cd {0} && git diff --name-only --diff-filter=A {1}"
+            "cd {0} && git diff --relative --name-only --diff-filter=A {1}"
         ).format(self.django_path, git_commit_id)
         logger.info("Executing {0}".format(git_diff_command))
         diff_process = Popen(git_diff_command, shell=True, stdout=PIPE, stderr=PIPE)


### PR DESCRIPTION
I've submitted this pull request to make sure file paths from git diff are relative to django_path instead of git repos root path.

Currently, the git diff command return file paths which are relative to git repos root path, which will cause invalid migration file path if git repos root path is different from django_path (for example, the django project is inside subdirectory of the git repos).