### PR TITLE
Quote migration name to avoid failures of migration with space in the name

### DIFF
--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -174,7 +174,7 @@ class MigrationLinter(object):
         it allows to seperate the instances correctly.
         """
         sqlmigrate_command = (
-            "cd {0} && {1} manage.py sqlmigrate {2} {3} --database {4}"
+            "cd {0} && {1} manage.py sqlmigrate {2} '{3}' --database {4}"
         ).format(
             self.django_path, sys.executable, app_name, migration_name, self.database
         )


### PR DESCRIPTION
we had some typo in old migration that contained space instead of one underscore. (`0052_added helper_in_form_element.py`). That would made sqlmigrate to fail since migration name is unquoted in the invocation. 