### PR TITLE
First check ignores then check cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 ## 1.0.0
 
-*Breaking changes* of the linter usage. The linter now is a Django management command.
-It shoud be used with a `python manage.py lintmigrations` followed by the usual options.
+**Breaking changes** of the linter usage. The linter now is a Django management command.
+It should be used with a `python manage.py lintmigrations` followed by the usual options.
 Additionally, the linter now needs to be added the to the `INSTALLED_APPS` in your Django settings.
 
 * The linter is now much faster: we don't setup django once for each migration
 * The linter is now more robust: we rely on Django internals to discover migrations
 * Clean up of the testing setup: it is cleaner, less brittle and we have more confidence that it works
+
+Fixed bugs:
+
+* Made the cache database-dependent. Between multiple databases, some migrations would be considered correct while they are not on the used DB.
+* Adding an erroneous migration to the ignore list on the second run would get the migration content from the cache and not ignore it.
 
 ## 0.1.5
 

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -96,13 +96,13 @@ class MigrationLinter(object):
 
         md5hash = self.get_migration_hash(app_label, migration_name)
 
-        if self.should_use_cache() and md5hash in self.old_cache:
-            self.lint_cached_migration(md5hash)
-            return
-
         if self.should_ignore_migration(app_label, migration_name):
             print("IGNORE")
             self.nb_ignored += 1
+            return
+
+        if self.should_use_cache() and md5hash in self.old_cache:
+            self.lint_cached_migration(md5hash)
             return
 
         sql_statements = self.get_sql(app_label, migration_name)


### PR DESCRIPTION
This gives you the possibility to add a errornous migration
to the ignore list. On the seccond run the linter will
first use the ignore list and not the cache first.