### PR TITLE
Lint only applied/unapplied migrations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,12 +43,11 @@ Add the migration linter your ``INSTALLED_APPS``:
     ]
 
 
-``python manage.py lintmigrations [GIT_COMMIT_ID] [--ignore-name-contains=IGNORE_NAME_CONTAINS] [--include-apps INCLUDE_APPS [INCLUDE_APPS ...] | --exclude-apps EXCLUDE_APPS [EXCLUDE_APPS ...]]``
+``python manage.py lintmigrations [GIT_COMMIT_ID] [--ignore-name-contains IGNORE_NAME_CONTAINS] [--include-apps INCLUDE_APPS [INCLUDE_APPS ...] | --exclude-apps EXCLUDE_APPS [EXCLUDE_APPS ...]]``
 
 ================================================== ===========================================================================================================================
                    Parameter                                                                            Description
 ================================================== ===========================================================================================================================
-``DJANGO_PROJECT_FOLDER``                          An absolute or relative path to the django project.
 ``GIT_COMMIT_ID``                                  If specified, only migrations since this commit will be taken into account. If not specified, all migrations will be linted.
 ``--ignore-name-contains IGNORE_NAME_CONTAINS``    Ignore migrations containing this name.
 ``--ignore-name IGNORE_NAME [IGNORE_NAME ...]``    Ignore migrations with exactly one of these names.

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,8 @@ Add the migration linter your ``INSTALLED_APPS``:
 ``--database DATABASE``                            Specify the database for which to generate the SQL. Defaults to *default*.
 ``--cache-path PATH``                              specify a directory that should be used to store cache-files in.
 ``--no-cache``                                     Don't use a cache.
+``--applied-migrations``                           Only lint migrations that are applied to the selected database. Other migrations are ignored.
+``--unapplied-migrations``                         Only lint migrations that are not yet applied to the selected database. Other migrations are ignored.
 ================================================== ===========================================================================================================================
 
 Examples

--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -71,6 +71,20 @@ class Command(BaseCommand):
             help="ignore migrations that are in the specified django apps",
         )
 
+        applied_unapplied_migrations_group = parser.add_mutually_exclusive_group(
+            required=False
+        )
+        applied_unapplied_migrations_group.add_argument(
+            "--unapplied-migrations",
+            action="store_true",
+            help="check only migrations have not been applied to the database yet",
+        )
+        applied_unapplied_migrations_group.add_argument(
+            "--applied-migrations",
+            action="store_true",
+            help="check only migrations that have already been applied to the database",
+        )
+
     def handle(self, *args, **options):
         settings_path = os.path.dirname(
             import_module(os.getenv("DJANGO_SETTINGS_MODULE")).__file__
@@ -90,6 +104,8 @@ class Command(BaseCommand):
             database=options["database"],
             cache_path=options["cache_path"],
             no_cache=options["no_cache"],
+            only_applied_migrations=options["applied_migrations"],
+            only_unapplied_migrations=options["unapplied_migrations"],
         )
         linter.lint_all_migrations(git_commit_id=options["commit_id"])
         linter.print_summary()

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -46,6 +46,8 @@ class MigrationLinter(object):
         database=DEFAULT_DB_ALIAS,
         cache_path=DEFAULT_CACHE_PATH,
         no_cache=False,
+        only_applied_migrations=False,
+        only_unapplied_migrations=False,
     ):
         # Store parameters and options
         self.django_path = path
@@ -56,6 +58,8 @@ class MigrationLinter(object):
         self.database = database or DEFAULT_DB_ALIAS
         self.cache_path = cache_path or DEFAULT_CACHE_PATH
         self.no_cache = no_cache
+        self.only_applied_migrations = only_applied_migrations
+        self.only_unapplied_migrations = only_unapplied_migrations
 
         # Initialise counters
         self.nb_valid = 0

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -241,4 +241,14 @@ class MigrationLinter(object):
                 and self.ignore_name_contains in migration_name
             )
             or (migration_name in self.ignore_name)
+            or (
+                self.only_applied_migrations
+                and (app_label, migration_name)
+                not in self.migration_loader.applied_migrations
+            )
+            or (
+                self.only_unapplied_migrations
+                and (app_label, migration_name)
+                in self.migration_loader.applied_migrations
+            )
         )

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -73,3 +73,17 @@ class LinterFunctionsTestCase(unittest.TestCase):
         linter = MigrationLinter()
         migrations = linter._gather_all_migrations()
         self.assertGreater(len(list(migrations)), 1)
+
+    def test_ignore_unapplied_migrations(self):
+        linter = MigrationLinter(only_applied_migrations=True)
+        linter.migration_loader.applied_migrations = {("app_correct", "0002_foo")}
+
+        self.assertTrue(linter.should_ignore_migration("app_correct", "0001_initial"))
+        self.assertFalse(linter.should_ignore_migration("app_correct", "0002_foo"))
+
+    def test_ignore_applied_migrations(self):
+        linter = MigrationLinter(only_unapplied_migrations=True)
+        linter.migration_loader.applied_migrations = {("app_correct", "0002_foo")}
+
+        self.assertFalse(linter.should_ignore_migration("app_correct", "0001_initial"))
+        self.assertTrue(linter.should_ignore_migration("app_correct", "0002_foo"))


### PR DESCRIPTION
Hi,

This tackles the feature request for being able to lint only unapplied migrations.
Took the occasion to implement also the inverse logic: only lint applied migrations.

This change adds the overhead of always discovering and loading the migrations *with a database connection* (https://github.com/3YOURMIND/django-migration-linter/compare/feature/minor/lint-unapplied-migrations?expand=1#diff-b120733e2c10f1f2282b060a55741f2dR79).
I think it is fine, but maybe the reviewers will see some unexpected implications.
The rest is pretty straightforward. A commit-by-commit review is encouraged and should be easier.

Fixes #56 