### PR TITLE
Feature/ignore migration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ services:
   - mysql
   - postgresql
 
+git:
+  depth: false
+
 matrix:
   include:
     - python: 2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+* Add `--exclude-migration-tests` option to ignore backward incompatible migration tests.
+
 ## 1.2.0
 
 * Add `--unapplied-migrations` and `--applied-migrations` mutually exclusive options

--- a/README.rst
+++ b/README.rst
@@ -43,25 +43,25 @@ Add the migration linter your ``INSTALLED_APPS``:
     ]
 
 
-``python manage.py lintmigrations [GIT_COMMIT_ID] [--ignore-name-contains IGNORE_NAME_CONTAINS] [--include-apps INCLUDE_APPS [INCLUDE_APPS ...] | --exclude-apps EXCLUDE_APPS [EXCLUDE_APPS ...]] [--exclude-tests EXCLUDE_TESTS [EXCLUDE TESTS ...]] [--project-root-path DJANGO_PROJECT_FOLDER]``
+``python manage.py lintmigrations [GIT_COMMIT_ID] [--ignore-name-contains IGNORE_NAME_CONTAINS] [--include-apps INCLUDE_APPS [INCLUDE_APPS ...] | --exclude-apps EXCLUDE_APPS [EXCLUDE_APPS ...]] [--exclude-migration-tests MIGRATION_TEST_CODE [MIGRATION_TEST_CODE ...]] [--project-root-path DJANGO_PROJECT_FOLDER]``
 
-================================================== ===========================================================================================================================
+================================================================ ===========================================================================================================================
                    Parameter                                                                            Description
-================================================== ===========================================================================================================================
-``GIT_COMMIT_ID``                                  If specified, only migrations since this commit will be taken into account. If not specified, all migrations will be linted.
-``--ignore-name-contains IGNORE_NAME_CONTAINS``    Ignore migrations containing this name.
-``--ignore-name IGNORE_NAME [IGNORE_NAME ...]``    Ignore migrations with exactly one of these names.
-``--include-apps INCLUDE_APPS [INCLUDE_APPS ...]`` Check only migrations that are in the specified django apps.
-``--exclude-apps EXCLUDE_APPS [EXCLUDE_APPS ...]`` Ignore migrations that are in the specified django apps.
-``--exclude-tests EXCLUDE_TESTS [EXCLUDE TES...]`` Specify tests to be ignored (e.g. ALTER_COLUMN).
-``--verbose or -v``                                Print more information during execution.
-``--database DATABASE``                            Specify the database for which to generate the SQL. Defaults to *default*.
-``--cache-path PATH``                              specify a directory that should be used to store cache-files in.
-``--no-cache``                                     Don't use a cache.
-``--applied-migrations``                           Only lint migrations that are applied to the selected database. Other migrations are ignored.
-``--unapplied-migrations``                         Only lint migrations that are not yet applied to the selected database. Other migrations are ignored.
-``--project-root-path DJANGO_PROJECT_FOLDER``      An absolute or relative path to the django project.
-================================================== ===========================================================================================================================
+================================================================ ===========================================================================================================================
+``GIT_COMMIT_ID``                                                If specified, only migrations since this commit will be taken into account. If not specified, all migrations will be linted.
+``--ignore-name-contains IGNORE_NAME_CONTAINS``                  Ignore migrations containing this name.
+``--ignore-name IGNORE_NAME [IGNORE_NAME ...]``                  Ignore migrations with exactly one of these names.
+``--include-apps INCLUDE_APPS [INCLUDE_APPS ...]``               Check only migrations that are in the specified django apps.
+``--exclude-apps EXCLUDE_APPS [EXCLUDE_APPS ...]``               Ignore migrations that are in the specified django apps.
+``--exclude-tests MIGRATION_TEST_CODE [MIGRATION_TEST_CODE...]`` Specify backward incompatible migration tests to be ignored using the code (e.g. ALTER_COLUMN).
+``--verbose or -v``                                              Print more information during execution.
+``--database DATABASE``                                          Specify the database for which to generate the SQL. Defaults to *default*.
+``--cache-path PATH``                                            specify a directory that should be used to store cache-files in.
+``--no-cache``                                                   Don't use a cache.
+``--applied-migrations``                                         Only lint migrations that are applied to the selected database. Other migrations are ignored.
+``--unapplied-migrations``                                       Only lint migrations that are not yet applied to the selected database. Other migrations are ignored.
+``--project-root-path DJANGO_PROJECT_FOLDER``                    An absolute or relative path to the django project.
+================================================================ ===========================================================================================================================
 
 Examples
 --------
@@ -100,14 +100,14 @@ You can also ignore migrations by adding this to your migrations:
         ]
     # ...
 
-Ignoring tests
--------------------
+Ignoring migration tests
+------------------------
 
-You can also ignore tests by adding this option during execution:
+You can also ignore backward incompatible migration tests by adding this option during execution:
 
-``python manage.py lintmigrations --exclude-tests EXCLUDE_TESTS``
+``python manage.py lintmigrations --exclude-migration-tests ALTER_COLUMN``
 
-The tests list can be found in sql_analyzer (migration_tests)
+The migration test codes can be found in the file ``django_migration_linter/sql_analyser.py``.
 
 Cache
 -----

--- a/README.rst
+++ b/README.rst
@@ -107,45 +107,7 @@ You can also ignore tests by adding this option during execution:
 
 ``python manage.py lintmigrations --exclude-tests EXCLUDE_TESTS``
 
-The tests list can be found in sql_analyzer (migration_tests):
-
-.. code-block::
-
-    migration_tests = (
-        {
-            "code": "NOT_NULL",
-            "fn": lambda sql, **kw: re.search("(?<!DROP) NOT NULL", sql)
-            and not re.search("CREATE TABLE", sql),
-            "err_msg": "NOT NULL constraint on columns",
-        },
-        {
-            "code": "DROP_COLUMN",
-            "fn": lambda sql, **kw: re.search("DROP COLUMN", sql),
-            "err_msg": "DROPPING columns",
-        },
-        {
-            "code": "RENAME_COLUMN",
-            "fn": lambda sql, **kw: re.search("ALTER TABLE .* CHANGE", sql)
-            or re.search("ALTER TABLE .* RENAME COLUMN", sql),
-            "err_msg": "RENAMING columns",
-        },
-        {
-            "code": "RENAME_TABLE",
-            "fn": lambda sql, **kw: re.search("RENAME TABLE", sql)
-            or re.search("ALTER TABLE .* RENAME TO", sql),
-            "err_msg": "RENAMING tables",
-        },
-        {
-            "code": "ALTER_COLUMN",
-            "fn": lambda sql, **kw: re.search("ALTER TABLE .* MODIFY", sql)
-            or re.search("ALTER TABLE .* ALTER COLUMN .* TYPE", sql),
-            "err_msg": (
-                "ALTERING columns (Could be backward compatible. "
-                "You may ignore this migration.)"
-            ),
-        },
-        {"code": "", "fn": has_default, "err_msg": ""},
-    )
+The tests list can be found in sql_analyzer (migration_tests)
 
 Cache
 -----

--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -50,11 +50,6 @@ class Command(BaseCommand):
             "--project-root-path", type=str, nargs="?", help="django project root path"
         )
 
-        parser.add_argument(
-            "--exclude-tests", type=str, nargs="*", help="Specify tests to be ignored"
-                                                         " (e.g. ALTER_COLUMN)"
-        )
-
         cache_group = parser.add_mutually_exclusive_group(required=False)
         cache_group.add_argument(
             "--cache-path",
@@ -93,6 +88,13 @@ class Command(BaseCommand):
             help="check only migrations that have already been applied to the database",
         )
 
+        parser.add_argument(
+            "--exclude-migration-tests",
+            type=str,
+            nargs="*",
+            help="Specify backward incompatible migration tests to be ignored (e.g. ALTER_COLUMN)",
+        )
+
     def handle(self, *args, **options):
         if options["project_root_path"]:
             settings_path = options["project_root_path"]
@@ -112,12 +114,12 @@ class Command(BaseCommand):
             ignore_name=options["ignore_name"],
             include_apps=options["include_apps"],
             exclude_apps=options["exclude_apps"],
-            exclude_tests=options["exclude_tests"],
             database=options["database"],
             cache_path=options["cache_path"],
             no_cache=options["no_cache"],
             only_applied_migrations=options["applied_migrations"],
             only_unapplied_migrations=options["unapplied_migrations"],
+            exclude_migration_tests=options["exclude_migration_tests"],
         )
         linter.lint_all_migrations(git_commit_id=options["commit_id"])
         linter.print_summary()

--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -50,6 +50,10 @@ class Command(BaseCommand):
             "--project-root-path", type=str, nargs="?", help="django project root path"
         )
 
+        parser.add_argument(
+            "--exclude-tests", type=str, nargs="*", help="Specify tests to be ignored (e.g. ALTER_COLUMN)"
+        )
+
         cache_group = parser.add_mutually_exclusive_group(required=False)
         cache_group.add_argument(
             "--cache-path",
@@ -107,6 +111,7 @@ class Command(BaseCommand):
             ignore_name=options["ignore_name"],
             include_apps=options["include_apps"],
             exclude_apps=options["exclude_apps"],
+            exclude_tests=options["exclude_tests"],
             database=options["database"],
             cache_path=options["cache_path"],
             no_cache=options["no_cache"],

--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -51,7 +51,8 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
-            "--exclude-tests", type=str, nargs="*", help="Specify tests to be ignored (e.g. ALTER_COLUMN)"
+            "--exclude-tests", type=str, nargs="*", help="Specify tests to be ignored"
+                                                         " (e.g. ALTER_COLUMN)"
         )
 
         cache_group = parser.add_mutually_exclusive_group(required=False)

--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -92,7 +92,8 @@ class Command(BaseCommand):
             "--exclude-migration-tests",
             type=str,
             nargs="*",
-            help="Specify backward incompatible migration tests to be ignored (e.g. ALTER_COLUMN)",
+            help="Specify backward incompatible migration tests "
+            "to be ignored (e.g. ALTER_COLUMN)",
         )
 
     def handle(self, *args, **options):

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -121,10 +121,16 @@ class MigrationLinter(object):
 
         sql_statements = self.get_sql(app_label, migration_name)
         exclude_migration_tests = self.exclude_migration_tests or []
-        errors = analyse_sql_statements(sql_statements, exclude_migration_tests)
+        errors, ignored = analyse_sql_statements(
+            sql_statements, exclude_migration_tests
+        )
 
         if not errors:
-            print("OK")
+            if ignored:
+                print("OK (ignored)")
+                self.print_errors(ignored)
+            else:
+                print("OK")
             self.nb_valid += 1
             if self.should_use_cache():
                 self.new_cache[md5hash] = {"result": "OK"}

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -42,12 +42,12 @@ class MigrationLinter(object):
         ignore_name=None,
         include_apps=None,
         exclude_apps=None,
-        exclude_tests=None,
         database=DEFAULT_DB_ALIAS,
         cache_path=DEFAULT_CACHE_PATH,
         no_cache=False,
         only_applied_migrations=False,
         only_unapplied_migrations=False,
+        exclude_migration_tests=None,
     ):
         # Store parameters and options
         self.django_path = path
@@ -55,7 +55,7 @@ class MigrationLinter(object):
         self.ignore_name = ignore_name or tuple()
         self.include_apps = include_apps
         self.exclude_apps = exclude_apps
-        self.exclude_tests = exclude_tests
+        self.exclude_migration_tests = exclude_migration_tests
         self.database = database or DEFAULT_DB_ALIAS
         self.cache_path = cache_path or DEFAULT_CACHE_PATH
         self.no_cache = no_cache
@@ -120,8 +120,8 @@ class MigrationLinter(object):
             return
 
         sql_statements = self.get_sql(app_label, migration_name)
-        exclude_tests = self.exclude_tests or []
-        errors = analyse_sql_statements(sql_statements, exclude_tests)
+        exclude_migration_tests = self.exclude_migration_tests or []
+        errors = analyse_sql_statements(sql_statements, exclude_migration_tests)
 
         if not errors:
             print("OK")

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -42,6 +42,7 @@ class MigrationLinter(object):
         ignore_name=None,
         include_apps=None,
         exclude_apps=None,
+        exclude_tests=None,
         database=DEFAULT_DB_ALIAS,
         cache_path=DEFAULT_CACHE_PATH,
         no_cache=False,
@@ -54,6 +55,7 @@ class MigrationLinter(object):
         self.ignore_name = ignore_name or tuple()
         self.include_apps = include_apps
         self.exclude_apps = exclude_apps
+        self.exclude_tests = exclude_tests
         self.database = database or DEFAULT_DB_ALIAS
         self.cache_path = cache_path or DEFAULT_CACHE_PATH
         self.no_cache = no_cache
@@ -118,7 +120,8 @@ class MigrationLinter(object):
             return
 
         sql_statements = self.get_sql(app_label, migration_name)
-        errors = analyse_sql_statements(sql_statements)
+        exclude_tests = self.exclude_tests or []
+        errors = analyse_sql_statements(sql_statements, exclude_tests)
 
         if not errors:
             print("OK")

--- a/django_migration_linter/sql_analyser.py
+++ b/django_migration_linter/sql_analyser.py
@@ -70,11 +70,11 @@ migration_tests = (
 )
 
 
-def analyse_sql_statements(sql_statements):
+def analyse_sql_statements(sql_statements, exclude_tests):
     errors = []
     for statement in sql_statements:
         for test in migration_tests:
-            if test["fn"](statement, errors=errors):
+            if test["code"] not in exclude_tests and test["fn"](statement, errors=errors):
                 logger.debug("Testing {0} -- ERROR".format(statement))
                 table_search = re.search("TABLE `([^`]*)`", statement, re.IGNORECASE)
                 col_search = re.search("COLUMN `([^`]*)`", statement, re.IGNORECASE)

--- a/django_migration_linter/sql_analyser.py
+++ b/django_migration_linter/sql_analyser.py
@@ -74,7 +74,8 @@ def analyse_sql_statements(sql_statements, exclude_tests):
     errors = []
     for statement in sql_statements:
         for test in migration_tests:
-            if test["code"] not in exclude_tests and test["fn"](statement, errors=errors):
+            if test["code"] not in exclude_tests and test["fn"](statement,
+                                                                errors=errors):
                 logger.debug("Testing {0} -- ERROR".format(statement))
                 table_search = re.search("TABLE `([^`]*)`", statement, re.IGNORECASE)
                 col_search = re.search("COLUMN `([^`]*)`", statement, re.IGNORECASE)

--- a/django_migration_linter/sql_analyser.py
+++ b/django_migration_linter/sql_analyser.py
@@ -70,12 +70,18 @@ migration_tests = (
 )
 
 
-def analyse_sql_statements(sql_statements, exclude_tests):
+def get_migration_tests(exclude_migration_tests):
+    for test in migration_tests:
+        if test["code"] in exclude_migration_tests:
+            continue
+        yield test
+
+
+def analyse_sql_statements(sql_statements, exclude_migration_tests):
     errors = []
     for statement in sql_statements:
-        for test in migration_tests:
-            if test["code"] not in exclude_tests and test["fn"](statement,
-                                                                errors=errors):
+        for test in get_migration_tests(exclude_migration_tests):
+            if test["fn"](statement, errors=errors):
                 logger.debug("Testing {0} -- ERROR".format(statement))
                 table_search = re.search("TABLE `([^`]*)`", statement, re.IGNORECASE)
                 col_search = re.search("COLUMN `([^`]*)`", statement, re.IGNORECASE)

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -87,3 +87,14 @@ class LinterFunctionsTestCase(unittest.TestCase):
 
         self.assertFalse(linter.should_ignore_migration("app_correct", "0001_initial"))
         self.assertTrue(linter.should_ignore_migration("app_correct", "0002_foo"))
+
+    def test_exclude_migration_tests(self):
+        m = Migration("0002_add_new_not_null_field", "app_add_not_null_column")
+
+        linter = MigrationLinter(exclude_migration_tests=[], database="mysql")
+        linter.lint_migration(m)
+        self.assertTrue(linter.has_errors)
+
+        linter = MigrationLinter(exclude_migration_tests=["NOT_NULL"], database="mysql")
+        linter.lint_migration(m)
+        self.assertFalse(linter.has_errors)

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,8 @@ deps =
 [testenv:lint]
 basepython = python3.6
 deps =
-    flake8
-    black
+    flake8==3.7.8
+    black==19.3b0
 commands =
     flake8 --max-line-length=88 django_migration_linter
     black --check django_migration_linter/ tests/ manage.py setup.py


### PR DESCRIPTION
* Add `--exclude-migration-tests`. Handles a migration has valid, but displays that the problem has been found.
* Add a unit test
* Fix git clone depth for Travis tests (by removing it)
* Fix linting dependency versions


Based on @vladmalynych s work