### PR TITLE
Hide linting messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add `--include-migrations-from` option to only consider migrations specified in a given file.
 No matter if the migrations are selected from a git commit or not, we only select the ones in the given file.
+* Add ``--quiet {ok,ignore,error}`` option to remove different or multiple types of messages from being printed to stdout.
 
 ## 1.3.0
 

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Add the migration linter your ``INSTALLED_APPS``:
     ]
 
 
-``python manage.py lintmigrations [GIT_COMMIT_ID] [--ignore-name-contains IGNORE_NAME_CONTAINS] [--include-apps INCLUDE_APPS [INCLUDE_APPS ...] | --exclude-apps EXCLUDE_APPS [EXCLUDE_APPS ...]] [--exclude-migration-tests MIGRATION_TEST_CODE [MIGRATION_TEST_CODE ...]] [--project-root-path DJANGO_PROJECT_FOLDER] [--include-migrations-from FILE_PATH]``
+``python manage.py lintmigrations [GIT_COMMIT_ID] [--ignore-name-contains IGNORE_NAME_CONTAINS] [--include-apps INCLUDE_APPS [INCLUDE_APPS ...] | --exclude-apps EXCLUDE_APPS [EXCLUDE_APPS ...]] [--exclude-migration-tests MIGRATION_TEST_CODE [MIGRATION_TEST_CODE ...]] [--project-root-path DJANGO_PROJECT_FOLDER] [--include-migrations-from FILE_PATH] [--quiet {ok,ignore,error} [{ok,ignore,error} ...]]``
 
 ================================================================ ===========================================================================================================================
                    Parameter                                                                            Description
@@ -62,6 +62,7 @@ Add the migration linter your ``INSTALLED_APPS``:
 ``--unapplied-migrations``                                       Only lint migrations that are not yet applied to the selected database. Other migrations are ignored.
 ``--project-root-path DJANGO_PROJECT_FOLDER``                    An absolute or relative path to the django project.
 ``--include-migrations-from FILE_PATH``                          If specified, only migrations listed in the given file will be considered.
+``--quiet or -q {ok,ignore,error}``                              Suppress certain output messages, instead of writing them to stdout.
 ================================================================ ===========================================================================================================================
 
 Examples

--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -7,7 +7,7 @@ from django.core.management.base import BaseCommand
 
 from ...constants import __version__
 
-from ...migration_linter import MigrationLinter
+from ...migration_linter import MigrationLinter, MessageType
 
 
 class Command(BaseCommand):
@@ -102,6 +102,14 @@ class Command(BaseCommand):
             "to be ignored (e.g. ALTER_COLUMN)",
         )
 
+        parser.add_argument(
+            "-q",
+            "--quiet",
+            nargs="+",
+            choices=MessageType.values(),
+            help="don't print linting messages to stdout",
+        )
+
     def handle(self, *args, **options):
         if options["project_root_path"]:
             settings_path = options["project_root_path"]
@@ -127,6 +135,7 @@ class Command(BaseCommand):
             only_applied_migrations=options["applied_migrations"],
             only_unapplied_migrations=options["unapplied_migrations"],
             exclude_migration_tests=options["exclude_migration_tests"],
+            quiet=options["quiet"],
         )
         linter.lint_all_migrations(
             git_commit_id=options["commit_id"],

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -23,6 +23,7 @@ from subprocess import Popen, PIPE
 from django.conf import settings
 from django.core.management import call_command
 from django.db import DEFAULT_DB_ALIAS, connections, ProgrammingError
+from enum import Enum, unique
 
 from .cache import Cache
 from .constants import DEFAULT_CACHE_PATH
@@ -33,6 +34,17 @@ from .sql_analyser import analyse_sql_statements
 logger = logging.getLogger(__name__)
 
 DJANGO_APPS_WITH_MIGRATIONS = ("admin", "auth", "contenttypes", "sessions")
+
+
+@unique
+class MessageType(Enum):
+    OK = "ok"
+    IGNORE = "ignore"
+    ERROR = "error"
+
+    @staticmethod
+    def values():
+        return list(map(lambda c: c.value, MessageType))
 
 
 class MigrationLinter(object):

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -61,6 +61,7 @@ class MigrationLinter(object):
         only_applied_migrations=False,
         only_unapplied_migrations=False,
         exclude_migration_tests=None,
+        quiet=None,
     ):
         # Store parameters and options
         self.django_path = path
@@ -74,6 +75,7 @@ class MigrationLinter(object):
         self.no_cache = no_cache
         self.only_applied_migrations = only_applied_migrations
         self.only_unapplied_migrations = only_unapplied_migrations
+        self.quiet = quiet or []
 
         # Initialise counters
         self.nb_valid = 0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,11 @@ setup(
     author_email="david.wobrock@gmail.com",
     license="Apache License 2.0",
     packages=find_packages(exclude=["tests/"]),
-    install_requires=["django>=1.11", "appdirs==1.4.3"],
+    install_requires=[
+        "django>=1.11",
+        "appdirs==1.4.3",
+        'enum34==1.1.6;python_version<"3.4"',
+    ],
     extras_require={
         "test": [
             "tox==3.9.0",


### PR DESCRIPTION
Add option to quiet the output of linting messages.
As suggested by @josh-stableprice 
To reduce the noise when having loads of migrations that are ok or ignored.

`--quiet {ok,ignore,error}`

The summary of execution is still printed no matter the options (for now).

Fixes #82 