### PR TITLE
Update testing dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+* Update testing dependencies (``mysqlclient``, Django 2.2 and ``black``)
+
 ## 1.4.0
 
 * Add `--include-migrations-from` option to only consider migrations specified in a given file.

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     extras_require={
         "test": [
             "tox==3.14.0",
-            "mysqlclient==1.4.4",
+            "mysqlclient==1.4.6",
             "psycopg2-binary==2.8.4",
             "django_add_default_value==0.3.2",
         ]

--- a/tox.ini
+++ b/tox.ini
@@ -12,15 +12,15 @@ deps =
     django111: django>=1.11,<2.0
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
-    django22: django>=2.2
+    django22: django>=2.2,<2.3
     appdirs==1.4.3
     py27: mock==2.0.0
 
 [testenv:lint]
 basepython = python3.6
 deps =
-    flake8==3.7.8
-    black==19.3b0
+    flake8==3.7.9
+    black==19.10b0
 commands =
     flake8 --max-line-length=88 django_migration_linter
     black --check django_migration_linter/ tests/ manage.py setup.py


### PR DESCRIPTION
mysqlclient
Django 2.2 fixed to not overlap to Django 3.0 which is under dev
black