### PR TITLE
Feature/Make output more friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,12 @@ $ python manage.py lintmigrations
 (app_rename_table, 0001_initial)... OK
 (app_rename_table, 0002_auto_20190414_1500)... ERR
         RENAMING tables
-*** Summary:
-Valid migrations: 4/8 - erroneous migrations: 3/8 - ignored migrations: 1/8
+
+*** Summary ***
+Valid migrations: 4/8
+Erroneous migrations: 3/8
+Migrations with warnings: 0/8
+Ignored migrations: 1/8
 ```
 
 The linter analysed all migrations from the Django project.

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -250,8 +250,7 @@ class MigrationLinter(object):
                 "Erroneous migrations: {2}/{0} \n"
                 "Migrations with warnings: {3}/{0} \n"
                 "Ignored migrations: {4}/{0}"
-            )
-            .format(
+            ).format(
                 self.nb_total,
                 self.nb_valid,
                 self.nb_erroneous,

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -242,14 +242,16 @@ class MigrationLinter(object):
             print(warn_str)
 
     def print_summary(self):
-        print("*** Summary:")
+        print("")
+        print("*** Summary ***")
         print(
             (
-                "Valid migrations: {1}/{0} - "
-                "erroneous migrations: {2}/{0} - "
-                "migrations with warnings: {3}/{0} - "
-                "ignored migrations: {4}/{0}"
-            ).format(
+                "Valid migrations: {1}/{0} \n"
+                "Erroneous migrations: {2}/{0} \n"
+                "Migrations with warnings: {3}/{0} \n"
+                "Ignored migrations: {4}/{0}"
+            )
+            .format(
                 self.nb_total,
                 self.nb_valid,
                 self.nb_erroneous,

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -242,22 +242,13 @@ class MigrationLinter(object):
             print(warn_str)
 
     def print_summary(self):
-        print("")
+        print()
         print("*** Summary ***")
-        print(
-            (
-                "Valid migrations: {1}/{0} \n"
-                "Erroneous migrations: {2}/{0} \n"
-                "Migrations with warnings: {3}/{0} \n"
-                "Ignored migrations: {4}/{0}"
-            ).format(
-                self.nb_total,
-                self.nb_valid,
-                self.nb_erroneous,
-                self.nb_warnings,
-                self.nb_ignored,
-            )
-        )
+        print("Valid migrations: {}/{}".format(self.nb_valid, self.nb_total))
+        print("Erroneous migrations: {}/{}".format(self.nb_erroneous, self.nb_total))
+        print("Erroneous migrations: {}/{}".format(self.nb_erroneous, self.nb_total))
+        print("Migrations with warnings: {}/{}".format(self.nb_warnings, self.nb_total))
+        print("Ignored migrations: {}/{}".format(self.nb_ignored, self.nb_total))
 
     @property
     def has_errors(self):


### PR DESCRIPTION
I added small changes to `print_summary` function to produce an output in a more readable way. E.g.:
```
(app, 0001_dog)... OK (cached)
(app, 0002_alias)... OK (cached)
(app, 0003_cat)... OK (cached)
(app, 0004_breed)... OK (cached)
*** Summary:
Valid migrations: 4/4 - erroneous migrations: 0/4 - migrations with warnings: 0/4 - ignored migrations: 0/4
```
vs.
```
(app, 0001_dog)... OK (cached)
(app, 0002_alias)... OK (cached)
(app, 0003_cat)... OK (cached)
(app, 0004_breed)... OK (cached)

*** Summary ***
Valid migrations: 4/4
Erroneous migrations: 0/4
Migrations with warnings: 0/4
Ignored migrations: 0/4
```