### PR TITLE
Handle get_model calls with linebreaks before and after arguments

### DIFF
--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -443,7 +443,7 @@ class MigrationLinter(object):
         for model in called_models:
             has_get_model_call = (
                 re.search(
-                    r"get_model\(.*?,.*?{}.+?\)".format(model), reverse_code_source
+                    r"get_model\(\s*?.*?,.*?{}.+?\s*?\)".format(model), reverse_code_source
                 )
                 is not None
             )

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -443,7 +443,8 @@ class MigrationLinter(object):
         for model in called_models:
             has_get_model_call = (
                 re.search(
-                    r"get_model\(\s*?.*?,.*?{}.+?\s*?\)".format(model), reverse_code_source
+                    r"get_model\(\s*?.*?,.*?{}.+?\s*?\)".format(model),
+                    reverse_code_source,
                 )
                 is not None
             )


### PR DESCRIPTION
For example code formatted with `black` could look something like this and is not picked up by the existing regex

```python
FreakishlyLongerThanUsualModel = get_model(
    'longerthanusualapp', 'FreakishlyLongerThanUsualModel'
)
```