### PR TITLE
Fix #112 -- make the behaviour of `--include-migrations-from` more obvious

### DIFF
--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -88,8 +88,12 @@ class LinterFunctionsTestCase(unittest.TestCase):
 
     def test_read_migrations_unknown_file(self):
         file_path = "unknown_file"
-        migration_list = MigrationLinter.read_migrations_list(file_path)
-        self.assertEqual([], migration_list)
+        with self.assertRaises(Exception):
+            MigrationLinter.read_migrations_list(file_path)
+
+    def test_read_migrations_no_file(self):
+        migration_list = MigrationLinter.read_migrations_list(None)
+        self.assertIsNone(migration_list)
 
     def test_read_migrations_empty_file(self):
         with tempfile.NamedTemporaryFile() as tmp:


### PR DESCRIPTION
Fixes #112 

* Misspelled filename => fail (instead of linting all migrations and ignoring the error)
* An empty file/a file with no valid migration paths => lint no migrations (instead oflinting all migrations)
* If the option is not specified, keep the behaviour of linting all migrations