### PR TITLE
Data migration detection improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add Python 3.9 support
 * Make data migration model import error less strict (issue #121)
 * Add warning detection on RunPython call when model variable name is not the same as model class name
+* Run checks on RunSQL migration operations
 
 Switched from Travis CI to GitHub Actions for tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.5.0
 
 * Add Python 3.9 support
+* Make data migration model import error less strict (issue #121)
 
 Switched from Travis CI to GitHub Actions for tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add Python 3.9 support
 * Make data migration model import error less strict (issue #121)
+* Add warning detection on RunPython call when model variable name is not the same as model class name
 
 Switched from Travis CI to GitHub Actions for tests
 

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -461,15 +461,15 @@ class MigrationLinter(object):
         model_object_regex = re.compile(r"[^a-zA-Z]?([a-zA-Z0-9]+?)\.objects")
 
         function_name = code.__name__
-        reverse_code_source = inspect.getsource(code)
+        source_code = inspect.getsource(code)
 
-        called_models = model_object_regex.findall(reverse_code_source)
+        called_models = model_object_regex.findall(source_code)
         issues = []
         for model in called_models:
             has_get_model_call = (
                 re.search(
-                    r"get_model\(\s*?.*?,.*?{}.+?\s*?\)".format(model),
-                    reverse_code_source,
+                    r"{}.*= +\w+\.get_model\(".format(model),
+                    source_code,
                 )
                 is not None
             )

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -9,7 +9,7 @@ from subprocess import Popen, PIPE
 
 from django.conf import settings
 from django.core.management import call_command
-from django.db import DEFAULT_DB_ALIAS, connections, ProgrammingError, connection
+from django.db import DEFAULT_DB_ALIAS, connections, ProgrammingError
 from django.db.migrations import RunPython, RunSQL
 from enum import Enum, unique
 from six import PY2
@@ -524,7 +524,7 @@ class MigrationLinter(object):
         for model in called_models:
             has_same_model_name = (
                 re.search(
-                    "{model}.*= +\w+?\.get_model\([^\)]+?\.{model}.*?\)".format(
+                    r"{model}.*= +\w+?\.get_model\([^)]+?\.{model}.*?\)".format(
                         model=model
                     ),
                     source_code,
@@ -532,7 +532,7 @@ class MigrationLinter(object):
                 )
                 is not None
                 or re.search(
-                    "{model}.*= +\w+?\.get_model\([^\)]+?,[^\)]*?{model}.*?\)".format(
+                    r"{model}.*= +\w+?\.get_model\([^)]+?,[^)]*?{model}.*?\)".format(
                         model=model
                     ),
                     source_code,
@@ -546,7 +546,8 @@ class MigrationLinter(object):
                         "code": "DATA_MIGRATION_MODEL_VARIABLE_NAME",
                         "msg": (
                             "'{}': Model variable name {} is different from the "
-                            "model class name that was found in the apps.get_model(...) call."
+                            "model class name that was found in the "
+                            "apps.get_model(...) call."
                         ).format(function_name, model),
                     }
                 )

--- a/docs/incompatibilities.md
+++ b/docs/incompatibilities.md
@@ -38,3 +38,4 @@ You can ignore check through the `--exclude-migration-test` option and specifyin
 |`NAMING_CONVENTION_RUNPYTHON_ARGS`   | By convention, RunPython names two arguments: apps, schema_editor
 |`DATA_MIGRATION_MODEL_IMPORT`        | Missing apps.get_model() calls for model
 |`DATA_MIGRATION_MODEL_VARIABLE_NAME` | The model variable name is different from the model class itself
+|`REVERSIBLE_RUNSQL_DATA_MIGRATION`   | RunSQL data migration is not reversible (missing reverse SQL)

--- a/docs/incompatibilities.md
+++ b/docs/incompatibilities.md
@@ -19,3 +19,20 @@ We are happy to add more if you can specify them to us.
 On data migrations, the linter will show a warning when:
 * you are missing a reverse migration
 * the RunPython arguments do not respect the naming convention `apps, schema_editor`
+
+## Codes
+
+You can ignore check through the `--exclude-migration-test` option and specifying any of the codes:
+
+|               Code                |            Description                                                                          |
+|-----------------------------------|----------------------------------------------------------------------|
+|`NOT_NULL`                         | Not NULL constraint on columns
+|`DROP_COLUMN`                      | Dropping columns
+|`DROP_TABLE`                       | Dropping tables
+|`RENAME_COLUMN`                    | Renaming columns
+|`RENAME_TABLE`                     | Renaming tables
+|`ALTER_COLUMN`                     | Altering columns (could be backward compatible)
+|`ADD_UNIQUE`                       | Add unique constraints
+|`REVERSIBLE_DATA_MIGRATION`        | RunPython data migration is not reversible (missing reverse code)
+|`NAMING_CONVENTION_RUNPYTHON_ARGS` | By convention, RunPython names two arguments: apps, schema_editor
+|`DATA_MIGRATION_MODEL_IMPORT`      | Missing apps.get_model() calls for model

--- a/docs/incompatibilities.md
+++ b/docs/incompatibilities.md
@@ -19,20 +19,22 @@ We are happy to add more if you can specify them to us.
 On data migrations, the linter will show a warning when:
 * you are missing a reverse migration
 * the RunPython arguments do not respect the naming convention `apps, schema_editor`
+* the model variable name is different from the model class name in the `get_model` call
 
 ## Codes
 
 You can ignore check through the `--exclude-migration-test` option and specifying any of the codes:
 
-|               Code                |            Description                                                                          |
-|-----------------------------------|----------------------------------------------------------------------|
-|`NOT_NULL`                         | Not NULL constraint on columns
-|`DROP_COLUMN`                      | Dropping columns
-|`DROP_TABLE`                       | Dropping tables
-|`RENAME_COLUMN`                    | Renaming columns
-|`RENAME_TABLE`                     | Renaming tables
-|`ALTER_COLUMN`                     | Altering columns (could be backward compatible)
-|`ADD_UNIQUE`                       | Add unique constraints
-|`REVERSIBLE_DATA_MIGRATION`        | RunPython data migration is not reversible (missing reverse code)
-|`NAMING_CONVENTION_RUNPYTHON_ARGS` | By convention, RunPython names two arguments: apps, schema_editor
-|`DATA_MIGRATION_MODEL_IMPORT`      | Missing apps.get_model() calls for model
+|               Code                  |            Description                                                                          |
+|-------------------------------------|----------------------------------------------------------------------|
+|`NOT_NULL`                           | Not NULL constraint on columns
+|`DROP_COLUMN`                        | Dropping columns
+|`DROP_TABLE`                         | Dropping tables
+|`RENAME_COLUMN`                      | Renaming columns
+|`RENAME_TABLE`                       | Renaming tables
+|`ALTER_COLUMN`                       | Altering columns (could be backward compatible)
+|`ADD_UNIQUE`                         | Add unique constraints
+|`REVERSIBLE_DATA_MIGRATION`          | RunPython data migration is not reversible (missing reverse code)
+|`NAMING_CONVENTION_RUNPYTHON_ARGS`   | By convention, RunPython names two arguments: apps, schema_editor
+|`DATA_MIGRATION_MODEL_IMPORT`        | Missing apps.get_model() calls for model
+|`DATA_MIGRATION_MODEL_VARIABLE_NAME` | The model variable name is different from the model class itself

--- a/tests/functional/test_data_migrations.py
+++ b/tests/functional/test_data_migrations.py
@@ -133,3 +133,109 @@ class DataMigrationModelImportTestCase(unittest.TestCase):
 
         issues = MigrationLinter.get_runpython_model_import_issues(forward_method)
         self.assertEqual(0, len(issues))
+
+
+class DataMigrationModelVariableNamingTestCase(unittest.TestCase):
+    def test_same_variable_name(self):
+        def forward_op(apps, schema_editor):
+            MyModel = apps.get_model("app", "MyModel")
+
+            MyModel.objects.filter(id=1).first()
+
+        issues = MigrationLinter.get_runpython_model_variable_naming_issues(forward_op)
+        self.assertEqual(0, len(issues))
+
+    def test_same_variable_name_multiline(self):
+        def forward_op(apps, schema_editor):
+            MyModelVeryLongLongLongLongLong = apps.get_model(
+                "app", "MyModelVeryLongLongLongLongLong"
+            )
+
+            MyModelVeryLongLongLongLongLong.objects.filter(id=1).first()
+
+        issues = MigrationLinter.get_runpython_model_variable_naming_issues(forward_op)
+        self.assertEqual(0, len(issues))
+
+    def test_same_variable_name_multiline2(self):
+        def forward_op(apps, schema_editor):
+            MyModelVeryLongLongLongLongLong = apps.get_model(
+                "app_name_longlonglonglongapp",
+                "MyModelVeryLongLongLongLongLong",
+            )
+
+            MyModelVeryLongLongLongLongLong.objects.filter(id=1).first()
+
+        issues = MigrationLinter.get_runpython_model_variable_naming_issues(forward_op)
+        self.assertEqual(0, len(issues))
+
+    def test_different_variable_name(self):
+        def forward_op(apps, schema_editor):
+            some_model = apps.get_model("app", "MyModel")
+
+            some_model.objects.filter(id=1).first()
+
+        issues = MigrationLinter.get_runpython_model_variable_naming_issues(forward_op)
+        self.assertEqual(1, len(issues))
+
+    def test_diff_variable_name_multiline(self):
+        def forward_op(apps, schema_editor):
+            MyModelVeryLongLongLongLongLongNot = apps.get_model(
+                "app", "MyModelVeryLongLongLongLongLong"
+            )
+
+            MyModelVeryLongLongLongLongLongNot.objects.filter(id=1).first()
+
+        issues = MigrationLinter.get_runpython_model_variable_naming_issues(forward_op)
+        self.assertEqual(1, len(issues))
+
+    def test_diff_variable_name_multiline2(self):
+        def forward_op(apps, schema_editor):
+            MyModelVeryLongLongLongLongLongNot = apps.get_model(
+                "app_name_longlonglonglongapp",
+                "MyModelVeryLongLongLongLongLong",
+            )
+
+            MyModelVeryLongLongLongLongLongNot.objects.filter(id=1).first()
+
+        issues = MigrationLinter.get_runpython_model_variable_naming_issues(forward_op)
+        self.assertEqual(1, len(issues))
+
+    def test_same_variable_name_one_param(self):
+        def forward_op(apps, schema_editor):
+            MyModel = apps.get_model("app.MyModel")
+
+            MyModel.objects.filter(id=1).first()
+
+        issues = MigrationLinter.get_runpython_model_variable_naming_issues(forward_op)
+        self.assertEqual(0, len(issues))
+
+    def test_different_variable_name_one_param(self):
+        def forward_op(apps, schema_editor):
+            mymodel = apps.get_model("app.MyModel")
+
+            mymodel.objects.filter(id=1).first()
+
+        issues = MigrationLinter.get_runpython_model_variable_naming_issues(forward_op)
+        self.assertEqual(1, len(issues))
+
+    def test_correct_variable_name_one_param_multiline(self):
+        def forward_op(apps, schema_editor):
+            AVeryLongModelName = apps.get_model(
+                "quite_long_app_name.AVeryLongModelName"
+            )
+
+            AVeryLongModelName.objects.filter(id=1).first()
+
+        issues = MigrationLinter.get_runpython_model_variable_naming_issues(forward_op)
+        self.assertEqual(0, len(issues))
+
+    def test_different_variable_name_one_param_multiline(self):
+        def forward_op(apps, schema_editor):
+            m = apps.get_model(
+                "quite_long_app_name_name_name.AVeryLongModelNameNameName"
+            )
+
+            m.objects.filter(id=1).first()
+
+        issues = MigrationLinter.get_runpython_model_variable_naming_issues(forward_op)
+        self.assertEqual(1, len(issues))

--- a/tests/functional/test_data_migrations.py
+++ b/tests/functional/test_data_migrations.py
@@ -74,7 +74,7 @@ class DataMigrationModelImportTestCase(unittest.TestCase):
 
             MyModel.objects.filter(id=1).first()
 
-        issues = MigrationLinter.get_data_migration_model_import_issues(
+        issues = MigrationLinter.get_runpython_model_import_issues(
             incorrect_importing_model_forward
         )
         self.assertEqual(1, len(issues))
@@ -94,7 +94,7 @@ class DataMigrationModelImportTestCase(unittest.TestCase):
             MyVeryLongLongLongModel.objects.filter(id=1).first()
             MultiLineModel.objects.all()
 
-        issues = MigrationLinter.get_data_migration_model_import_issues(
+        issues = MigrationLinter.get_runpython_model_import_issues(
             correct_importing_model_forward
         )
         self.assertEqual(0, len(issues))
@@ -109,7 +109,7 @@ class DataMigrationModelImportTestCase(unittest.TestCase):
 
             User.objects.filter(id=1).first()
 
-        issues = MigrationLinter.get_data_migration_model_import_issues(forward_method)
+        issues = MigrationLinter.get_runpython_model_import_issues(forward_method)
         self.assertEqual(0, len(issues))
 
     def test_correct_one_param_get_model_import(self):
@@ -118,7 +118,7 @@ class DataMigrationModelImportTestCase(unittest.TestCase):
 
             User.objects.filter(id=1).first()
 
-        issues = MigrationLinter.get_data_migration_model_import_issues(forward_method)
+        issues = MigrationLinter.get_runpython_model_import_issues(forward_method)
         self.assertEqual(0, len(issues))
 
     def test_not_overlapping_one_param(self):
@@ -131,5 +131,5 @@ class DataMigrationModelImportTestCase(unittest.TestCase):
 
             User.objects.filter(id=1).first()
 
-        issues = MigrationLinter.get_data_migration_model_import_issues(forward_method)
+        issues = MigrationLinter.get_runpython_model_import_issues(forward_method)
         self.assertEqual(0, len(issues))


### PR DESCRIPTION
Fix https://github.com/3YOURMIND/django-migration-linter/issues/121

* Make data migration model import error less strict
* Add warning detection on RunPython call when model variable name is not the same as model class name
* Run checks on RunSQL migration operations

I'll add some more tests and feature on the RunSQL call