### PR TITLE
Add option to lintmigrations to accept path to a single migration file

### DIFF
--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -40,12 +40,19 @@ class Command(BaseCommand):
         parser.add_argument(
             "--project-root-path", type=str, nargs="?", help="django project root path"
         )
-        parser.add_argument(
+        filepath_group = parser.add_mutually_exclusive_group()
+        filepath_group.add_argument(
             "--include-migrations-from",
             metavar="FILE_PATH",
             type=str,
             nargs="?",
             help="if specified, only migrations listed in the file will be considered",
+        )
+        filepath_group.add_argument(
+            "--migration-file",
+            type=str,
+            nargs="?",
+            help="if specified, only the specified migration file will be considered",
         )
         cache_group = parser.add_mutually_exclusive_group(required=False)
         cache_group.add_argument(
@@ -106,7 +113,6 @@ class Command(BaseCommand):
             logging.basicConfig(format="%(message)s", level=logging.DEBUG)
         else:
             logging.basicConfig(format="%(message)s")
-
         linter = MigrationLinter(
             settings_path,
             ignore_name_contains=options["ignore_name_contains"],
@@ -125,6 +131,7 @@ class Command(BaseCommand):
         linter.lint_all_migrations(
             git_commit_id=options["commit_id"],
             migrations_file_path=options["include_migrations_from"],
+            single_file_path=options["migration_file"],
         )
         linter.print_summary()
         if linter.has_errors:

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -97,9 +97,16 @@ class MigrationLinter(object):
     def should_use_cache(self):
         return self.django_path and not self.no_cache
 
-    def lint_all_migrations(self, git_commit_id=None, migrations_file_path=None, single_file_path=None):
+    def lint_all_migrations(
+        self,
+        git_commit_id=None,
+        migrations_file_path=None,
+        single_file_path=None,
+    ):
         # Collect migrations
-        migrations_list = self.read_migrations_list(migrations_file_path, single_file_path)
+        migrations_list = self.read_migrations_list(
+            migrations_file_path, single_file_path
+        )
         if git_commit_id:
             migrations = self._gather_migrations_git(git_commit_id, migrations_list)
         else:

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -291,7 +291,7 @@ class MigrationLinter(object):
         )
 
     @classmethod
-    def read_migrations_list(cls, migrations_file_path, single_file_path):
+    def read_migrations_list(cls, migrations_file_path, single_file_path=None):
         """
         Returning an empty list is different from returning None here.
         None: no file was specified and we should consider all migrations

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,6 +24,7 @@ Detailed command line options:
 |`--unapplied-migrations`                                      | Only lint migrations that are not yet applied to the selected database. Other migrations are ignored.                       |
 |`--project-root-path DJANGO_PROJECT_FOLDER`                   | An absolute or relative path to the django project.                                                                         |
 |`--include-migrations-from FILE_PATH`                         | If specified, only migrations listed in the given file will be considered.                                                  |
+|`--migration-file FILE_PATH`                                  | If specified, only the specified migration file will be considered                                                          |
 |`--quiet or -q {ok,ignore,warning,error}`                     | Suppress certain output messages, instead of writing them to stdout.                                                        |
 |`--warnings-as-errors`                                        | Handle warnings as errors and therefore return an error status code if we should.                                           |
 


### PR DESCRIPTION
For our use case, we have a long running projects with a lot of migrations and we want to inject this to engineer's flow so that they can be alerted before even putting up code for review.

Add an option to lintmigration command so we can pass it a specific file path. Making it mutually exclusive with the `include-migrations-from` option as well.

Tested locally and confirm both option is working correctly
```
./manage.py lintmigrations --include-migrations-from ~/test.txt
(test, 0011_migration)... OK (cached)

*** Summary ***
Valid migrations: 1/1
Erroneous migrations: 0/1
Migrations with warnings: 0/1
Ignored migrations: 0/1


./manage.py lintmigrations --migration-file /Users/andy.dau/test/apps/test/migrations/0011_migration.py
INFO 2021-01-14 18:22:25,937 migration_linter Calling sqlmigrate command inquiries 0011_migration
(test, 0011_migration)... OK

*** Summary ***
Valid migrations: 1/1
Erroneous migrations: 0/1
Migrations with warnings: 0/1
Ignored migrations: 0/1
```

Confirm that error throws when both options are added
```
./manage.py lintmigrations --include-migrations-from ~/test.txt --migration-file /Users/andy.dau/test/apps/test/migrations/0011_migration.py
usage: manage.py lintmigrations [-h] [--ignore-name-contains [IGNORE_NAME_CONTAINS]] [--ignore-name [IGNORE_NAME [IGNORE_NAME ...]]] [--project-root-path [PROJECT_ROOT_PATH]]
                                [--include-migrations-from [FILE_PATH] | --migration-file [MIGRATION_FILE]] [--cache-path CACHE_PATH | --no-cache]
                                [--include-apps [INCLUDE_APPS [INCLUDE_APPS ...]] | --exclude-apps [EXCLUDE_APPS [EXCLUDE_APPS ...]]]
                                [--unapplied-migrations | --applied-migrations] [-q {ok,ignore,warning,error} [{ok,ignore,warning,error} ...]] [--database [DATABASE]]
                                [--exclude-migration-tests [EXCLUDE_MIGRATION_TESTS [EXCLUDE_MIGRATION_TESTS ...]]] [--warnings-as-errors] [--version] [-v {0,1,2,3}]
                                [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
                                [GIT_COMMIT_ID]
manage.py lintmigrations: error: argument --migration-file: not allowed with argument --include-migrations-from
```

Let me know if there are unit test I should be updating as well