### PR TITLE
Add options to include migration name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Features/fixes:
 * Rename the RunPython data migration lint checks for improved consistency
 * Refactor and commonise the loggers, so that all modules the `django_migration_linter` logger
 * Allow using configuration file for linter options
+* Add option `--include-name` and `--include-name-contains` to only include migration with a certain name
 
 Others:
 * Switched from Travis CI to GitHub Actions for tests

--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -48,6 +48,18 @@ class Command(BaseCommand):
             help="ignore migrations with exactly one of these names",
         )
         parser.add_argument(
+            "--include-name-contains",
+            type=str,
+            nargs="?",
+            help="only consider migrations containing this name",
+        )
+        parser.add_argument(
+            "--include-name",
+            type=str,
+            nargs="*",
+            help="only consider migrations with exactly one of these names",
+        )
+        parser.add_argument(
             "--project-root-path", type=str, nargs="?", help="django project root path"
         )
         parser.add_argument(
@@ -126,6 +138,12 @@ class Command(BaseCommand):
         ignore_name = options["ignore_name"] or config_parser.get(
             CONFIG_NAME, "ignore_name", fallback=None
         )
+        include_name_contains = options["include_name_contains"] or config_parser.get(
+            CONFIG_NAME, "include_name_contains", fallback=None
+        )
+        include_name = options["include_name"] or config_parser.get(
+            CONFIG_NAME, "include_name", fallback=None
+        )
         include_apps = options["include_apps"] or config_parser.get(
             CONFIG_NAME, "include_apps", fallback=None
         )
@@ -163,6 +181,8 @@ class Command(BaseCommand):
             settings_path,
             ignore_name_contains=ignore_name_contains,
             ignore_name=ignore_name,
+            include_name_contains=include_name_contains,
+            include_name=include_name,
             include_apps=include_apps,
             exclude_apps=exclude_apps,
             database=database,

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -45,6 +45,8 @@ class MigrationLinter(object):
         path=None,
         ignore_name_contains=None,
         ignore_name=None,
+        include_name_contains=None,
+        include_name=None,
         include_apps=None,
         exclude_apps=None,
         database=DEFAULT_DB_ALIAS,
@@ -60,6 +62,8 @@ class MigrationLinter(object):
         self.django_path = path
         self.ignore_name_contains = ignore_name_contains
         self.ignore_name = ignore_name or tuple()
+        self.include_name_contains = include_name_contains
+        self.include_name = include_name or tuple()
         self.include_apps = include_apps
         self.exclude_apps = exclude_apps
         self.exclude_migration_tests = exclude_migration_tests or []
@@ -371,7 +375,12 @@ class MigrationLinter(object):
                 self.ignore_name_contains
                 and self.ignore_name_contains in migration_name
             )
+            or (
+                self.include_name_contains
+                and self.include_name_contains not in migration_name
+            )
             or (migration_name in self.ignore_name)
+            or (self.include_name and migration_name not in self.include_name)
             or (
                 self.only_applied_migrations
                 and (app_label, migration_name)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,6 +13,8 @@ Below the detailed command line options, which can all also be defined using a c
 |`GIT_COMMIT_ID`                                               | If specified, only migrations since this commit will be taken into account. If not specified, all migrations will be linted.|
 |`--ignore-name-contains IGNORE_NAME_CONTAINS`                 | Ignore migrations containing this name.                                                                                     |
 |`--ignore-name IGNORE_NAME [IGNORE_NAME ...]`                 | Ignore migrations with exactly one of these names.                                                                          |
+|`--include-name-contains INCLUDE_NAME_CONTAINS`               | Include migrations containing this name.                                                                                     |
+|`--include-name INCLUDE_NAME [INCLUDE_NAME ...]`              | Include migrations with exactly one of these names.                                                                          |
 |`--include-apps INCLUDE_APPS [INCLUDE_APPS ...]`              | Check only migrations that are in the specified django apps.                                                                |
 |`--exclude-apps EXCLUDE_APPS [EXCLUDE_APPS ...]`              | Ignore migrations that are in the specified django apps.                                                                    |
 |`--exclude-migration-tests MIGRATION_TEST_CODE [...]`         | Specify backward incompatible migration tests to be ignored using the code (e.g. ALTER_COLUMN).                             |

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -56,6 +56,22 @@ class LinterFunctionsTestCase(unittest.TestCase):
         self.assertFalse(linter.should_ignore_migration("app_correct", "0001_initial"))
         self.assertTrue(linter.should_ignore_migration("app_correct", "0002_foo"))
 
+    def test_include_migration_name_contains(self):
+        linter = MigrationLinter(include_name_contains="foo")
+        self.assertTrue(linter.should_ignore_migration("app_correct", "0001_initial"))
+        self.assertFalse(linter.should_ignore_migration("app_correct", "0002_foo"))
+
+    def test_include_migration_full_name(self):
+        linter = MigrationLinter(include_name=("0002_foo",))
+        self.assertTrue(linter.should_ignore_migration("app_correct", "0001_initial"))
+        self.assertFalse(linter.should_ignore_migration("app_correct", "0002_foo"))
+
+    def test_include_migration_multiple_names(self):
+        linter = MigrationLinter(include_name=("0002_foo", "0003_bar"))
+        self.assertTrue(linter.should_ignore_migration("app_correct", "0001_initial"))
+        self.assertFalse(linter.should_ignore_migration("app_correct", "0002_foo"))
+        self.assertFalse(linter.should_ignore_migration("app_correct", "0003_bar"))
+
     def test_gather_all_migrations(self):
         linter = MigrationLinter()
         migrations = linter._gather_all_migrations()


### PR DESCRIPTION
Add `--include-name` and `--include-name-contains` options, just like the existing `--ignore...` options, but reversed