### PR TITLE
Remove toml support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.2
+
+* Remove `toml` support for config files
+
 ## 2.5.1
 
 * Remove `.editorconfig` from default config file

--- a/django_migration_linter/constants.py
+++ b/django_migration_linter/constants.py
@@ -1,6 +1,6 @@
 from appdirs import user_cache_dir
 
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 
 DEFAULT_CACHE_PATH = user_cache_dir("django-migration-linter", version=__version__)
 

--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -13,7 +13,6 @@ from ..utils import register_linting_configuration_options
 CONFIG_NAME = "django_migration_linter"
 DEFAULT_CONFIG_FILES = (
     ".{}.cfg".format(CONFIG_NAME),
-    "pyproject.toml",
     "setup.cfg",
     "tox.ini",
 )

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@ The linter is installed as a Django app and is integrated through the Django man
 
 `python manage.py lintmigrations [GIT_COMMIT_ID] ...`
 
-Below the detailed command line options, which can all also be defined using a config file (`setup.cfg`, `tox.ini`, `pyproject.toml`, `.django_migration_linter.cfg`):
+Below the detailed command line options, which can all also be defined using a config file (`setup.cfg`, `tox.ini`, `.django_migration_linter.cfg`):
 
 |                   Parameter                                  |                                        Description                                                                          |
 |--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Since this configuration files has some issues with `configparser`, let's remove it in the next version to make the linter usable again.

We'll see for the next version how to nicely at it again :)

Fixes #144
and makes #145 unnecessary