### PR TITLE
Fix setup 'packages' argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.3
+
+* Stop packaging the 'tests' module into the release wheel file
+
 ## 2.5.2
 
 * Remove `toml` support for config files

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,7 @@
 include README.md
 include LICENSE
+include CHANGELOG.md
+include MANIFEST.in
+recursive-include docs *
+recursive-include tests *.py
+include tox.ini

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author="3YOURMIND GmbH",
     author_email="david.wobrock@gmail.com",
     license="Apache License 2.0",
-    packages=find_packages(exclude=["tests/"]),
+    packages=find_packages(include=["django_migration_linter*"]),
     install_requires=[
         "django>=1.11",
         "appdirs>=1.4.3",


### PR DESCRIPTION
So that we don't install a 'tests' module globally in each env

Fixes https://github.com/3YOURMIND/django-migration-linter/issues/147