### PR TITLE
Change lintmigrations API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
-* Renamed `master` branch to `main`
+## 3.0.0
+
+**Breaking API change on `lintmigrations` command**:
+* the positional argument `GIT_COMMIT_ID` becomes an optional argument with the named parameter ` --git-commit-id [GIT_COMMIT_ID]`
+* the `lintmigrations` command takes now two positional arguments: `lintmigrations [app_label] [migration_name]`
+
+Miscellaneous:
 * Add complete and working support for `toml` configuration files
+* Renamed `master` branch to `main`
 
 ## 2.5.3
 

--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -27,6 +27,18 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
+            "app_label",
+            nargs="?",
+            type=str,
+            help="App label of an application to lint migrations.",
+        )
+        parser.add_argument(
+            "migration_name",
+            nargs="?",
+            type=str,
+            help="Linting will only be done on that migration only.",
+        )
+        parser.add_argument(
             "--git-commit-id",
             type=str,
             nargs="?",
@@ -191,6 +203,8 @@ class Command(BaseCommand):
             warnings_as_errors=config["warnings_as_errors"],
         )
         linter.lint_all_migrations(
+            app_label=options["app_label"],
+            migration_name=options["migration_name"],
             git_commit_id=options["git_commit_id"],
             migrations_file_path=options["include_migrations_from"],
         )

--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -27,14 +27,12 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "commit_id",
-            metavar="GIT_COMMIT_ID",
+            "--git-commit-id",
             type=str,
             nargs="?",
             help=(
                 "if specified, only migrations since this commit "
-                "will be taken into account. If not specified, "
-                "the initial repo commit will be used"
+                "will be taken into account"
             ),
         )
         parser.add_argument(
@@ -193,7 +191,7 @@ class Command(BaseCommand):
             warnings_as_errors=config["warnings_as_errors"],
         )
         linter.lint_all_migrations(
-            git_commit_id=options["commit_id"],
+            git_commit_id=options["git_commit_id"],
             migrations_file_path=options["include_migrations_from"],
         )
         linter.print_summary()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,17 +4,28 @@
 
 The linter is installed as a Django app and is integrated through the Django management command system. 
 
-`python manage.py lintmigrations [GIT_COMMIT_ID] ...`
+`python manage.py lintmigrations [app_label] [migration_name]`
+
+The three main usages are:
+
+* Lint your entire code base
+`python manage.py lintmigrations`
+
+* Lint one Django app
+`python manage.py lintmigrations app_label`
+
+* Lint a specific migration
+`python manage.py lintmigrations app_label migration_name`
 
 Below the detailed command line options, which can all also be defined using a config file (`setup.cfg`, `tox.ini`, `.django_migration_linter.cfg`):
 
 |                   Parameter                                  |                                        Description                                                                          |
 |--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-|`GIT_COMMIT_ID`                                               | If specified, only migrations since this commit will be taken into account. If not specified, all migrations will be linted.|
+|`--git-commit-id GIT_COMMIT_ID`                               | If specified, only migrations since this commit will be taken into account.                                                 |
 |`--ignore-name-contains IGNORE_NAME_CONTAINS`                 | Ignore migrations containing this name.                                                                                     |
 |`--ignore-name IGNORE_NAME [IGNORE_NAME ...]`                 | Ignore migrations with exactly one of these names.                                                                          |
-|`--include-name-contains INCLUDE_NAME_CONTAINS`               | Include migrations containing this name.                                                                                     |
-|`--include-name INCLUDE_NAME [INCLUDE_NAME ...]`              | Include migrations with exactly one of these names.                                                                          |
+|`--include-name-contains INCLUDE_NAME_CONTAINS`               | Include migrations containing this name.                                                                                    |
+|`--include-name INCLUDE_NAME [INCLUDE_NAME ...]`              | Include migrations with exactly one of these names.                                                                         |
 |`--include-apps INCLUDE_APPS [INCLUDE_APPS ...]`              | Check only migrations that are in the specified django apps.                                                                |
 |`--exclude-apps EXCLUDE_APPS [EXCLUDE_APPS ...]`              | Ignore migrations that are in the specified django apps.                                                                    |
 |`--exclude-migration-tests MIGRATION_TEST_CODE [...]`         | Specify backward incompatible migration tests to be ignored using the code (e.g. ALTER_COLUMN).                             |
@@ -67,5 +78,5 @@ The migration test codes can be found in the [corresponding source code files](.
 ## Production usage example
 
 [3YOURMIND](https://www.3yourmind.com/) is running the linter on every build getting pushed through CI.
-That enables to be sure that the migrations will allow A/B testing, Blue/Green deployment and they won't break your development environment.
+That enables to be sure that the migrations will allow A/B testing, Blue/Green deployment, and they won't break your development environment.
 A non-zero error code is returned to express that at least one invalid migration has been found.

--- a/tests/functional/test_migration_linter.py
+++ b/tests/functional/test_migration_linter.py
@@ -23,16 +23,12 @@ class BaseBackwardCompatibilityDetection(object):
         self.assertNotEqual(linter.nb_valid + linter.nb_erroneous, 0)
 
     def _launch_linter(self, app=None, commit_id=None):
-        if app is not None:
-            app = [app]
-
         linter = MigrationLinter(
             self.test_project_path,
-            include_apps=app,
             database=next(iter(self.databases)),
             no_cache=True,
         )
-        linter.lint_all_migrations(git_commit_id=commit_id)
+        linter.lint_all_migrations(app_label=app, git_commit_id=commit_id)
         return linter
 
     # *** Tests ***


### PR DESCRIPTION
To be closer to Django's `makemigrations` and `migrate` commands API, we stop taking a git commit id as positional argument, but instead take `app_label` and `migration_name`.

Fixes #135 