### PR TITLE
Default ends_with_default to `False`

### DIFF
--- a/django_migration_linter/sql_analyser/base.py
+++ b/django_migration_linter/sql_analyser/base.py
@@ -8,7 +8,7 @@ logger = logging.getLogger("django_migration_linter")
 
 def has_not_null_column(sql_statements, **kwargs):
     # TODO: improve to detect that the same column is concerned
-    ends_with_default = None
+    ends_with_default = False
     for sql in sql_statements:
         if "SET DEFAULT" in sql:
             ends_with_default = True

--- a/tests/unit/test_sql_analyser.py
+++ b/tests/unit/test_sql_analyser.py
@@ -171,6 +171,21 @@ class PostgresqlAnalyserTestCase(SqlAnalyserTestCase):
         ]
         self.assertValidSql(sql)
 
+    def test_field_to_not_null_with_dropped_default(self):
+        sql = [
+            'ALTER TABLE "api_example_example" ALTER COLUMN "foo_id" SET DEFAULT 42;',
+            'UPDATE "example_example" SET "foo_id" = 42 WHERE "foo_id" IS NULL;',
+            'ALTER TABLE "example_example" ALTER COLUMN "foo_id" SET NOT NULL;',
+            'ALTER TABLE "example_example" ALTER COLUMN "foo_id" DROP DEFAULT;',
+        ]
+        self.assertBackwardIncompatibleSql(sql)
+
+    def test_onetoonefield_to_not_null(self):
+        sql = [
+            'ALTER TABLE "example_example" ALTER COLUMN "foo" SET NOT NULL;',
+        ]
+        self.assertBackwardIncompatibleSql(sql)
+
     def test_drop_not_null(self):
         sql = 'ALTER TABLE "app_alter_column_drop_not_null_a" ALTER COLUMN "not_null_field" DROP NOT NULL;'
         self.assertValidSql(sql)


### PR DESCRIPTION
Problem: Previously in gh-117 we aimed to solve gh-115, which described a problem where we used `SET DEFAULT` and then `DROP DEFAULT` immediately afterward. The solution was to track whether any defaults are retained, but the `ends_with_default` variable is initialized as `None` rather than `False`. At the end of the function we check whether `ends_with_default is False`, never occurs unless a default is set.

Solution: Assume that there is no default unless proven otherwise, and iniitializie `ends_with_default` to `False` instead of `None`.

Fixes: gh-158