### PR TITLE
Raju | fix typo in incompatibilities doc

### DIFF
--- a/docs/incompatibilities.md
+++ b/docs/incompatibilities.md
@@ -23,7 +23,7 @@ On data migrations, the linter will show a warning when:
 
 ## Codes
 
-You can ignore check through the `--exclude-migration-test` option and specifying any of the codes:
+You can ignore check through the `--exclude-migration-tests` option and specifying any of the codes:
 
 |               Code                |            Description                                               |
 |-----------------------------------|----------------------------------------------------------------------|


### PR DESCRIPTION
- Fix a typo in the doc of a command argument.