### PR TITLE
docs: fix IgnoreMigration link

### DIFF
--- a/docs/incompatibilities.md
+++ b/docs/incompatibilities.md
@@ -111,7 +111,7 @@ Deletion operations often lead to errors during deployment.
 :white_check_mark: **Solutions**:
 - Deprecate the column before dropping it using [django-deprecate-fields](https://github.com/3YOURMIND/django-deprecate-fields/).
 This process requires to first make sure that the field is unused (for which `django-deprecate-fields` is made for).
-Once the column is unsed, drop it in a migration. This migration will require to be ignored through the [IgnoreMigration](docs/usage.md#ignoring-migrations) for instance.
+Once the column is unsed, drop it in a migration. This migration will require to be ignored through the [IgnoreMigration](/docs/usage.md#ignoring-migrations) for instance.
 - Don't actually drop the column, but fake the drop migration until you are sure you won't roll back.
 Be careful :warning: fake dropping a non-nullable column without a database default will create errors once the code is not aware of the column anymore.
 


### PR DESCRIPTION
Previously, this link tried to open <https://github.com/3YOURMIND/django-migration-linter/blob/main/docs/docs/usage.md#ignoring-migrations>, which 404s:

![Screen Shot 2022-02-14 at 12 09 09 PM](https://user-images.githubusercontent.com/630449/153929989-5db79a84-a17a-4748-b8d7-f6432c1cb4ff.png)

By adding a leading slash, the link works properly.

PS. Thank you for this extremely useful tool ❤️ 