### PR TITLE
Allow passing '--sql-analyser' to makemigrations command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 4.x.y (unreleased)
+## 4.1.0 (unreleased)
 
-- Allow configuring logging for `makemigrations` command and unify behaviour with `lintmigrations`
-- Adapt `--warnings-as-errors` option to allow selecting some migration tests only
+- Allow configuring logging for `makemigrations` command and unify behaviour with `lintmigrations` (issue #207)
+- Adapt `--warnings-as-errors` option to allow selecting some migration tests only (issue #201)
+- Add `sql_analyser` option to `makemigrations` in order to specify the SQL analyser to use (issue #208)
 
 ## 4.0.0
 

--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -10,7 +10,6 @@ from django.core.management.base import BaseCommand
 
 from ...constants import __version__
 from ...migration_linter import MessageType, MigrationLinter
-from ...sql_analyser.analyser import ANALYSER_STRING_MAPPING
 from ..utils import (
     configure_logging,
     extract_warnings_as_errors_option,
@@ -129,12 +128,6 @@ class Command(BaseCommand):
             nargs="+",
             choices=MessageType.values(),
             help="don't print linting messages to stdout",
-        )
-        parser.add_argument(
-            "--sql-analyser",
-            nargs="?",
-            choices=list(ANALYSER_STRING_MAPPING.keys()),
-            help="select the SQL analyser",
         )
         register_linting_configuration_options(parser)
 

--- a/django_migration_linter/management/commands/makemigrations.py
+++ b/django_migration_linter/management/commands/makemigrations.py
@@ -46,6 +46,7 @@ class Command(MakeMigrationsCommand):
         self.database = options["database"]
         self.exclude_migrations_tests = options["exclude_migration_tests"]
         self.warnings_as_errors = options["warnings_as_errors"]
+        self.sql_analyser = options["sql_analyser"]
         configure_logging(options["verbosity"])
         return super(Command, self).handle(*app_labels, **options)
 
@@ -85,6 +86,7 @@ class Command(MakeMigrationsCommand):
             exclude_migration_tests=self.exclude_migrations_tests,
             warnings_as_errors_tests=warnings_as_errors_tests,
             all_warnings_as_errors=all_warnings_as_errors,
+            analyser_string=self.sql_analyser,
         )
 
         for app_label, app_migrations in changes.items():

--- a/django_migration_linter/management/utils.py
+++ b/django_migration_linter/management/utils.py
@@ -1,5 +1,7 @@
 import logging
 
+from ..sql_analyser.analyser import ANALYSER_STRING_MAPPING
+
 
 def register_linting_configuration_options(parser):
     parser.add_argument(
@@ -25,6 +27,13 @@ def register_linting_configuration_options(parser):
         nargs="*",
         help="handle warnings as errors. Optionally specify the tests to handle as "
         "errors (e.g. RUNPYTHON_REVERSIBLE)",
+    )
+
+    parser.add_argument(
+        "--sql-analyser",
+        nargs="?",
+        choices=list(ANALYSER_STRING_MAPPING.keys()),
+        help="select the SQL analyser",
     )
 
 


### PR DESCRIPTION
Fixes https://github.com/3YOURMIND/django-migration-linter/issues/208