### PR TITLE
Improve error message when an unsupported database vendor/SQL analyser was selected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,23 @@ It will save you time by making sure migrations will not break with a older code
 pip install django-migration-linter
 ```
 
-And add the migration linter your ``INSTALLED_APPS``:
+And add the migration linter to your ``INSTALLED_APPS``:
 ```
-    INSTALLED_APPS = [
-        ...,
-        "django_migration_linter",
-        ...,
-    ]
+INSTALLED_APPS = [
+    ...,
+    "django_migration_linter",
+    ...,
+]
 ```
+
+Optionally, add a configuration:
+```
+MIGRATION_LINTER_OPTIONS = {
+    ...
+}
+```
+
+For details about configuration options, checkout [Usage](docs/usage.md).
 
 ## Usage example
 

--- a/django_migration_linter/sql_analyser/analyser.py
+++ b/django_migration_linter/sql_analyser/analyser.py
@@ -24,7 +24,10 @@ def get_sql_analyser_class(database_vendor, analyser_string=None):
 def get_sql_analyser_from_string(analyser_string):
     if analyser_string not in ANALYSER_STRING_MAPPING:
         raise ValueError(
-            "Unknown SQL analyser. Known values: {}".format(analyser_string.keys())
+            "Unknown SQL analyser '{}'. Known values: '{}'".format(
+                analyser_string,
+                "','".join(ANALYSER_STRING_MAPPING.keys()),
+            )
         )
     return ANALYSER_STRING_MAPPING[analyser_string]
 
@@ -37,7 +40,11 @@ def get_sql_analyser_class_from_db_vendor(database_vendor):
     elif "sqlite" in database_vendor:
         sql_analyser_class = SqliteAnalyser
     else:
-        raise ValueError("Unsupported database vendor. Try specifying an SQL analyser.")
+        raise ValueError(
+            "Unsupported database vendor '{}'. Try specifying an SQL analyser.".format(
+                database_vendor
+            )
+        )
 
     logger.debug("Chosen SQL analyser class: %s", sql_analyser_class)
     return sql_analyser_class

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,7 +17,14 @@ The three main usages are:
 * Lint a specific migration
 `python manage.py lintmigrations app_label migration_name`
 
-Below the detailed command line options, which can all also be defined using a config file (`setup.cfg`, `tox.ini`, `pyproject.toml`, `.django_migration_linter.cfg`):
+Below the detailed command line options, which can all also be defined using a config file:
+- `settings.py`
+- `setup.cfg`
+- `tox.ini`
+- `pyproject.toml`
+- `.django_migration_linter.cfg`
+
+If you are using a config file, replace any dashes (`-`) with an underscore (`_`).
 
 | Parameter                                             | Description                                                                                                                                                                                                     |
 |-------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/tests/unit/test_sql_analyser.py
+++ b/tests/unit/test_sql_analyser.py
@@ -310,3 +310,19 @@ class PostgresqlAnalyserTestCase(SqlAnalyserTestCase):
         self.assertWarningSql(sql)
         sql = "REINDEX TABLE my_table;"
         self.assertWarningSql(sql)
+
+
+class SqlUtilsTestCase(unittest.TestCase):
+    def test_unknown_analyser_string(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unknown SQL analyser 'unknown'. Known values: 'sqlite','mysql','postgresql'",
+        ):
+            get_sql_analyser_class("db", "unknown")
+
+    def test_unsupported_db_vendor(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unsupported database vendor 'unknown'. Try specifying an SQL analyser.",
+        ):
+            get_sql_analyser_class("unknown")


### PR DESCRIPTION
Supersedes https://github.com/3YOURMIND/django-migration-linter/pull/228 