### PR TITLE
Use a context manager to write to /dev/null

### DIFF
--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -302,15 +302,15 @@ class MigrationLinter:
 
     def get_sql(self, app_label, migration_name):
         logger.info(f"Calling sqlmigrate command {app_label} {migration_name}")
-        dev_null = open(os.devnull, "w")
         try:
-            sql_statement = call_command(
-                "sqlmigrate",
-                app_label,
-                migration_name,
-                database=self.database,
-                stdout=dev_null,
-            )
+            with open(os.devnull, "w") as dev_null:
+                sql_statement = call_command(
+                    "sqlmigrate",
+                    app_label,
+                    migration_name,
+                    database=self.database,
+                    stdout=dev_null,
+                )
         except (ValueError, ProgrammingError):
             logger.warning(
                 "Error while executing sqlmigrate on (%s, %s).",


### PR DESCRIPTION
When executing, Python will issue a following warning:

```
<interpreter_path>/site-packages/django_migration_linter/migration_linter.py:169: ResourceWarning: unclosed file <_io.TextIOWrapper name='/dev/null' mode='w' encoding='UTF-8'>
  sql_statements = self.get_sql(app_label, migration_name)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

It is only seen if one enables the Python warnings (for example, by using the `-Wall` flag).

I am not educated enough to guess whether closing /dev/null is such a big issue; in either way, I personally don't like unclosed files in my code :)

This PR replaces raw file opening with `with open(...)` and pulls it inside the `try:` clause so that the file can be closed as soon as the migration is complete.