### PR TITLE
Only make a connection to the DB if necessary

### DIFF
--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -98,8 +98,10 @@ class MigrationLinter:
         # Initialise migrations
         from django.db.migrations.loader import MigrationLoader
 
+        connection = connections[self.database] if self.only_applied_migrations or self.only_unapplied_migrations else None
+
         self.migration_loader = MigrationLoader(
-            connection=connections[self.database], load=True
+            connection=connection, load=True
         )
 
     def reset_counters(self) -> None:


### PR DESCRIPTION
When updating to Django 4 I noticed that suddenly our CI failed as there was no valid database while linting migrations. This change will only connect to a DB when it is necessary (i.e. check only applied or unapplied migrations). That way you don't have to do trickery in your settings file when you run the linter without a DB.