### PR TITLE
Issue/235/support makemmigration customisation

### DIFF
--- a/django_migration_linter/management/commands/lintmigrations.py
+++ b/django_migration_linter/management/commands/lintmigrations.py
@@ -9,9 +9,10 @@ from django.core.management.base import BaseCommand, CommandParser
 from ...constants import __version__
 from ...migration_linter import MessageType, MigrationLinter
 from ..utils import (
+    configure_logging,
     extract_warnings_as_errors_option,
-    load_config,
     register_linting_configuration_options,
+    set_defaults_from_conf,
 )
 
 
@@ -120,10 +121,11 @@ class Command(BaseCommand):
             help="don't print linting messages to stdout",
         )
         register_linting_configuration_options(parser)
+        set_defaults_from_conf(parser)
 
     def handle(self, *args, **options):
 
-        options = load_config(options)
+        configure_logging(options["verbosity"])
        
         (
             warnings_as_errors_tests,

--- a/django_migration_linter/management/commands/makemigrations.py
+++ b/django_migration_linter/management/commands/makemigrations.py
@@ -14,9 +14,10 @@ from django.db.migrations.writer import MigrationWriter
 from django_migration_linter import MigrationLinter
 
 from ..utils import (
+    configure_logging,
     extract_warnings_as_errors_option,
-    load_config,
     register_linting_configuration_options,
+    set_defaults_from_conf,
 )
 
 
@@ -45,9 +46,11 @@ class Command(MakeMigrationsCommand):
             help="Lint newly generated migrations.",
         )
         register_linting_configuration_options(parser)
+        set_defaults_from_conf(parser)
+
 
     def handle(self, *app_labels, **options):
-        options = load_config(options)
+        configure_logging(options["verbosity"])
 
         self.lint = options["lint"]
         self.database = options["database"]

--- a/django_migration_linter/management/commands/makemigrations.py
+++ b/django_migration_linter/management/commands/makemigrations.py
@@ -14,8 +14,8 @@ from django.db.migrations.writer import MigrationWriter
 from django_migration_linter import MigrationLinter
 
 from ..utils import (
-    configure_logging,
     extract_warnings_as_errors_option,
+    load_config,
     register_linting_configuration_options,
 )
 
@@ -47,12 +47,13 @@ class Command(MakeMigrationsCommand):
         register_linting_configuration_options(parser)
 
     def handle(self, *app_labels, **options):
+        options = load_config(options)
+
         self.lint = options["lint"]
         self.database = options["database"]
         self.exclude_migrations_tests = options["exclude_migration_tests"]
         self.warnings_as_errors = options["warnings_as_errors"]
         self.sql_analyser = options["sql_analyser"]
-        configure_logging(options["verbosity"])
         return super().handle(*app_labels, **options)
 
     def write_migration_files(self, changes: dict[str, list[Migration]]) -> None:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -99,3 +99,7 @@ The migration test codes can be found in the [corresponding source code files](.
 [3YOURMIND](https://www.3yourmind.com/) is running the linter on every build getting pushed through CI.
 That enables to be sure that the migrations will allow A/B testing, Blue/Green deployment, and they won't break your development environment.
 A non-zero error code is returned to express that at least one invalid migration has been found.
+
+
+## Postgis
+You might be able to get away with using the `postgresql` sql analyser option with PostGIS. This can be configured using the `sql_analyser` option.

--- a/tests/unit/files/test_config.toml
+++ b/tests/unit/files/test_config.toml
@@ -1,2 +1,3 @@
 [tool.django_migration_linter]
 sql_analyser = "postgresql"
+not_a_real_setting = true

--- a/tests/unit/files/test_config.toml
+++ b/tests/unit/files/test_config.toml
@@ -1,0 +1,2 @@
+[tool.django_migration_linter]
+sql_analyser = "postgresql"

--- a/tests/unit/files/test_setup.cfg
+++ b/tests/unit/files/test_setup.cfg
@@ -1,0 +1,2 @@
+[django_migration_linter]
+traceback = True

--- a/tests/unit/files/test_setup.cfg
+++ b/tests/unit/files/test_setup.cfg
@@ -1,2 +1,3 @@
 [django_migration_linter]
 traceback = True
+not_a_real_setting = true

--- a/tests/unit/test_management_utils.py
+++ b/tests/unit/test_management_utils.py
@@ -1,0 +1,103 @@
+import os
+from unittest.mock import patch
+
+import unittest
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from django_migration_linter.management import utils
+
+
+EXAMPLE_OPTIONS = {
+    "verbosity": 1,
+    "settings": None,
+    "pythonpath": None,
+    "traceback": False,
+    "no_color": False,
+    "force_color": False,
+    "skip_checks": False,
+    "dry_run": False,
+    "merge": False,
+    "empty": False,
+    "interactive": True,
+    "name": None,
+    "include_header": True,
+    "check_changes": False,
+    "scriptable": False,
+    "update": False,
+    "lint": False,
+    "database": None,
+    "exclude_migration_tests": None,
+    "warnings_as_errors": None,
+    "sql_analyser": None,
+}
+
+
+def get_test_path(filename: str) -> str:
+    """
+    Returns path to test files
+    """
+    return os.path.join(os.path.dirname(__file__), f"files/{filename}")
+
+
+class LoadConfigTestCase(unittest.TestCase):
+    @patch(
+        "django_migration_linter.management.utils.PYPROJECT_TOML",
+        get_test_path("test_config.toml"),
+    )
+    def test_read_toml_file_exists(self):
+        """
+        Check we can read config options from a toml file.
+        """
+        toml_options = utils.read_toml_file(EXAMPLE_OPTIONS)
+        expected = {"sql_analyser": "postgresql"}
+        self.assertDictEqual(toml_options, expected)
+
+    def test_read_toml_file_dn_exist(self):
+        """
+        Check no errors are raised if the toml file does not exist.
+        """
+        toml_options = utils.read_toml_file(EXAMPLE_OPTIONS)
+        expected = {}
+        self.assertDictEqual(toml_options, expected)
+
+    @patch(
+        "django_migration_linter.management.utils.DEFAULT_CONFIG_FILES",
+        get_test_path("test_setup.cfg"),
+    )
+    def test_read_config_file_exists(self):
+        """
+        Check we can read config options from a config file
+        """
+        cfg_options = utils.read_config_file(EXAMPLE_OPTIONS)
+        expected = {"traceback": True}
+        self.assertDictEqual(cfg_options, expected)
+
+    def test_read_config_file_dn_exist(self):
+        """
+        Check no errors are raised if the .cfg file does not exist.
+        """
+        cfg_options = utils.read_config_file(EXAMPLE_OPTIONS)
+        expected = {}
+        self.assertDictEqual(cfg_options, expected)
+
+    # @override_settings(
+    #     MIGRATION_LINTER_OPTIONS={"interactive": False, "name": "test_name"}
+    # )
+    # def test_read_django_settings_exist(self):
+    #     django_options = utils.read_django_settings(EXAMPLE_OPTIONS)
+    #     expected = {"interactive": False, "name": "test_name"}
+    #     self.assertDictEqual(django_options, expected)
+
+    def test_read_django_settings_dn_exist(self):
+        """
+        Check no errors are raised if the settings key does not exist.
+        """
+        django_options = utils.read_django_settings(EXAMPLE_OPTIONS)
+        expected = {}
+        self.assertDictEqual(django_options, expected)
+
+    def test_load_config_priority(self):
+        """ """
+
+        options = utils.load_config(EXAMPLE_OPTIONS)


### PR DESCRIPTION
Harmonises the makemigrations and lintmigrations config loading code and sorts the priority order.
As it was before, only Falsy default values could be overwritten by config options. I would also expect the command line to take priority over the config files.

This PR makes an opinionated preference for ordering of config sources where higher priority sources override lower priority settings. Open to discussion:

    1. Command line
    2. Django Settings
    3. Config files
    4. pyproject.toml

closes #235 