### PR TITLE
Avoid spawning a shell when spawning subprocess for git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Miscellaneous:
 
 - Migrated from `setup.py` and `setup.cfg` to `pyproject.toml`
 - Add support for Python 3.12
+- Avoid git command injections
 
 ## 5.0.0
 

--- a/src/django_migration_linter/migration_linter.py
+++ b/src/django_migration_linter/migration_linter.py
@@ -374,11 +374,21 @@ class MigrationLinter:
     ) -> Iterable[Migration]:
         migrations = []
         # Get changes since specified commit
-        git_diff_command = (
-            "cd {} && git diff --relative --name-only --diff-filter=AR {}"
-        ).format(self.django_path, git_commit_id)
-        logger.info(f"Executing {git_diff_command}")
-        diff_process = Popen(git_diff_command, shell=True, stdout=PIPE, stderr=PIPE)
+        git_diff_command = [
+            "git",
+            "diff",
+            "--relative",
+            "--name-only",
+            "--diff-filter=AR",
+            git_commit_id,
+        ]
+        logger.info(f"Executing {git_diff_command} (in {self.django_path})")
+        diff_process = Popen(
+            git_diff_command,
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd=self.django_path,
+        )
         for line in map(
             clean_bytes_to_str, diff_process.stdout.readlines()  # type: ignore
         ):


### PR DESCRIPTION
This avoids security shenanigans that can come if your `git-commit-id` may come from potentially untrusted source (e.g. a build/linter service's API), an attacker could trick the build system to run lint commands like:

```
./manage.py lintmigrations --git-commit-id '; rm -rf dangerous'
```

or perhaps a malicious project may set a config like and told you to run `lintmigrations`:

```toml
[tool.django_migration_linter]
git_commit_id = "; rm -rf dangerous"
```

