### PR TITLE
Don't consider partial unique index creation as making a column not nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Feature:
 
 Bug:
 - Don't detect 'IS NOT NULL' as backward incompatible changes (issue #263)
+- Don't consider UNIQUE INDEX creation as making a column not nullable
 
 Miscellaneous:
 

--- a/src/django_migration_linter/sql_analyser/base.py
+++ b/src/django_migration_linter/sql_analyser/base.py
@@ -37,7 +37,9 @@ def has_not_null_column(sql_statements: list[str], **kwargs) -> bool:
 
     for sql in sql_statements:
         if re.search("(?<!DROP )(?<!IS )NOT NULL", sql) and not (
-            sql.startswith("CREATE TABLE") or sql.startswith("CREATE INDEX")
+            sql.startswith("CREATE TABLE")
+            or sql.startswith("CREATE INDEX")
+            or sql.startswith("CREATE UNIQUE INDEX")
         ):
             not_null_column = True
         if re.search("DEFAULT.*NOT NULL", sql):

--- a/tests/unit/test_sql_analyser.py
+++ b/tests/unit/test_sql_analyser.py
@@ -336,6 +336,10 @@ class PostgresqlAnalyserTestCase(SqlAnalyserTestCase):
         sql = 'CREATE INDEX CONCURRENTLY "index_name" ON "table_name" ("a_column") WHERE ("some_column" IS NOT NULL);'
         self.assertValidSql(sql)
 
+    def test_create_unique_index_concurrently_where(self):
+        sql = 'CREATE UNIQUE INDEX CONCURRENTLY "index_name" ON "table_name" ("a_column") WHERE ("some_column" IS NOT NULL);'
+        self.assertBackwardIncompatibleSql(sql, "ADD_UNIQUE")
+
     def test_drop_index_non_concurrently(self):
         sql = "DROP INDEX ON films"
         self.assertWarningSql(sql)


### PR DESCRIPTION
One more fix related to #250: the current regex match only makes an exception for "CREATE INDEX" but not "CREATE UNIQUE INDEX", which is safe for the same reasons

Same idea as the fix in #258 