### PR TITLE
Fix #292 Run in FIPS enabled environment with python3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Miscellaneous:
 - Add support for Python 3.13
 - Add support for Django 5.1
 - Drop support for Python 3.7 and 3.8
+- Mark md5 hashing as not used for security
 
 ## 5.1.0
 

--- a/src/django_migration_linter/migration_linter.py
+++ b/src/django_migration_linter/migration_linter.py
@@ -231,7 +231,7 @@ class MigrationLinter:
 
     @staticmethod
     def get_migration_hash(app_label: str, migration_name: str) -> str:
-        hash_md5 = hashlib.md5()
+        hash_md5 = hashlib.md5(usedforsecurity=False)
         with open(get_migration_abspath(app_label, migration_name), "rb") as f:
             for chunk in iter(lambda: f.read(4096), b""):
                 hash_md5.update(chunk)


### PR DESCRIPTION
Python 3.10 and later versions rely on OpenSSL 1.1.1 or newer, which includes FIPS-compliance checks.

MD5 is not an approved algorithm in FIPS mode, so attempting to instantiate hashlib.md5() will fail when the system is running in FIPS mode. Since MD5 is used in a non-security context, the change adds the [_usedforsecurity_](https://docs.python.org/3/library/hashlib.html) flag.

The same issue in Django https://github.com/django/django/commit/d10c7bfe56f025ccc690721c9f13e7029b777b9c