### PR TITLE
Allow ignoring initial migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.x.y
 
+Feature:
+- Allow ignoring all initial migrations, with `--ignore-initial-migrations`
+
 Bug:
 - Don't detect an index creation during a transaction with an exclusive lock, when the table is being created (#264)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,6 +48,7 @@ If you are using a config file, replace any dashes (`-`) with an underscore (`_`
 | `--warnings-as-errors [MIGRATION_TEST_CODE [...]]`    | Handle warnings as errors and therefore return an error status code if we should. Optionally specify migration test codes to handle as errors. When no test code specified, all warnings are handled as errors. |
 | `--sql-analyser`                                      | Specify the SQL analyser that should be used. Allowed values: 'sqlite', 'mysql', 'postgresql'.                                                                                                                  |
 | `--ignore-sqlmigrate-errors`                          | Ignore failures of sqlmigrate commands.                                                                                                                                                                         |
+| `--ignore-initial-migrations`                         | Ignore initial migrations.                                                                                                                                                                                      |
 
 ## Django settings configuration
 
@@ -86,6 +87,7 @@ class Migration(migrations.Migration):
 ```
 
 Or you can restrict the migrations that should be selected by a file containing there paths with the `--include-migrations-from` option.
+Or you can ignore all initial migrations with the `--ignore-initial-migrations` option.
 
 ## Ignoring migration tests
 

--- a/src/django_migration_linter/management/commands/lintmigrations.py
+++ b/src/django_migration_linter/management/commands/lintmigrations.py
@@ -176,6 +176,7 @@ class Command(BaseCommand):
             no_output=options["verbosity"] == 0,
             analyser_string=options["sql_analyser"],
             ignore_sqlmigrate_errors=options["ignore_sqlmigrate_errors"],
+            ignore_initial_migrations=options["ignore_initial_migrations"],
         )
         linter.lint_all_migrations(
             app_label=options["app_label"],

--- a/src/django_migration_linter/management/utils.py
+++ b/src/django_migration_linter/management/utils.py
@@ -46,6 +46,12 @@ def register_linting_configuration_options(parser: CommandParser) -> None:
         help="ignore failures of sqlmigrate command",
     )
 
+    parser.add_argument(
+        "--ignore-initial-migrations",
+        action="store_true",
+        help="ignore initial migrations",
+    )
+
 
 def configure_logging(verbosity: int) -> None:
     logger = logging.getLogger("django_migration_linter")

--- a/tests/unit/test_linter.py
+++ b/tests/unit/test_linter.py
@@ -170,3 +170,15 @@ class LinterFunctionsTestCase(unittest.TestCase):
             ]
         )
         self.assertEqual(2, len(list(migrations)))
+
+    def test_ignore_initial_migrations(self):
+        linter = MigrationLinter(ignore_initial_migrations=True)
+
+        self.assertTrue(
+            linter.should_ignore_migration(
+                "app_correct", "0001_initial", is_initial=True
+            )
+        )
+        self.assertFalse(
+            linter.should_ignore_migration("app_correct", "0002_foo", is_initial=False)
+        )


### PR DESCRIPTION
Sometimes, if your apps have cyclic dependencies or complicated FK structure, django migrations creates multiple initial migration files, which can very easily fail linting because they are adding foreign keys or constraints etc.

This adds an option to automatically ignore all initial migrations.

The specific motivation behind this PR is making it easier to squash migrations in bulk. I've been experimenting with `django-remake-migrations` which is another great package, but in my primary work app after remaking migrations I had to go in and ignore about a dozen initial migrations to make linting pass, which is kind of annoying and makes it harder to automate the process