### PR TITLE
feat(git): Use AMR mode for diff-filter option

### DIFF
--- a/src/django_migration_linter/migration_linter.py
+++ b/src/django_migration_linter/migration_linter.py
@@ -396,7 +396,7 @@ class MigrationLinter:
             "diff",
             "--relative",
             "--name-only",
-            "--diff-filter=AR",
+            "--diff-filter=AMR",
             git_commit_id,
         ]
         logger.info(f"Executing {git_diff_command} (in {self.django_path})")


### PR DESCRIPTION
Currently, the diff-filter option in the `git diff command is AR. This means that only added or renamed files are taken into account.

However, in a case where a migration is updated, we want to be able to lint it anyways. So, changing the diff-filter mode to AMR should take that into account.